### PR TITLE
DOCS-563: Add Zuplo config: HDX transform, HDX openapi schema, Grafana dashboards

### DIFF
--- a/zuplo/grafana-dashboards/zuplo-geo-distribution.json
+++ b/zuplo/grafana-dashboards/zuplo-geo-distribution.json
@@ -1,0 +1,786 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_HYDROLIX_- SBXZUPLOTWIST",
+      "label": "Hydrolix - sbxzuplotwist",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    },
+    {
+      "name": "DS_HYDROLIX_- SBXZUPLOTWIST-FOR-LIBRARY-PANEL",
+      "label": "Hydrolix - sbxzuplotwist",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse",
+      "usage": {
+        "libraryPanels": [
+          {
+            "name": "Zuplo: Current Most Active Timezones",
+            "uid": "eecxq6tlm1se8e"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VAR_TABLE",
+      "type": "constant",
+      "label": "Table",
+      "value": "sbxzuplotwist.zuplotest",
+      "description": ""
+    }
+  ],
+  "__elements": {
+    "fecxq41xxgni8a": {
+      "name": "Zuplo: Traffic Location Geo (Percentage)",
+      "uid": "fecxq41xxgni8a",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The geographic location of API requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#6ED0E0",
+                  "value": 5
+                },
+                {
+                  "color": "#EF843C",
+                  "value": 10
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 20
+                },
+                {
+                  "color": "#447EBC",
+                  "value": 30
+                },
+                {
+                  "color": "#CCA300",
+                  "value": 40
+                },
+                {
+                  "color": "#508642",
+                  "value": 50
+                },
+                {
+                  "color": "#705DA0",
+                  "value": 60
+                },
+                {
+                  "color": "#BA43A9",
+                  "value": 70
+                },
+                {
+                  "color": "#1F78C1",
+                  "value": 80
+                },
+                {
+                  "color": "#E24D42",
+                  "value": 90
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": true,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "nightColor": "#a7a6ba4D",
+                "show": "to",
+                "sun": false
+              },
+              "name": "Night/Day",
+              "opacity": 0.4,
+              "tooltip": true,
+              "type": "dayNight"
+            },
+            {
+              "config": {
+                "showLegend": true,
+                "style": {
+                  "color": {
+                    "field": "percentage_band",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "percentage",
+                    "fixed": 5,
+                    "max": 20,
+                    "min": 1
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "text": {
+                    "field": "percentage_band",
+                    "fixed": "",
+                    "mode": "fixed"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "Geo as Percentages"
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "Location",
+              "tooltip": true,
+              "type": "markers"
+            }
+          ],
+          "tooltip": {
+            "mode": "none"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "coords",
+            "lat": 12.0028,
+            "lon": 11.636296,
+            "zoom": 2
+          }
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    latitude,\n    longitude,\n    CASE\n        WHEN percentage < 5 THEN 1  -- Band 1\n        WHEN percentage >= 5 AND percentage < 10 THEN 2  -- Band 2\n        WHEN percentage >= 10 AND percentage < 20 THEN 3  -- Band 3\n        WHEN percentage >= 20 AND percentage < 30 THEN 4  -- Band 4\n        WHEN percentage >= 30 AND percentage < 40 THEN 5  -- Band 5\n        WHEN percentage >= 40 AND percentage < 50 THEN 6  -- Band 6\n        WHEN percentage >= 50 AND percentage < 60 THEN 7  -- Band 7\n        WHEN percentage >= 60 AND percentage < 70 THEN 8  -- Band 8\n        WHEN percentage >= 70 AND percentage < 80 THEN 9  -- Band 9\n        WHEN percentage >= 80 AND percentage < 90 THEN 10  -- Band 10\n        WHEN percentage >= 90 AND percentage <= 100 THEN 11  -- Band 9\n        ELSE 0  -- Default (shouldn't happen)\n    END AS percentage_band, percentage\nFROM (\n    SELECT\n        latitude,\n        longitude,\n        ROUND((request_count / sum(request_count) OVER ()) * 100, 2) AS percentage  -- Round to 2 decimal places\n    FROM (\n        SELECT\n            latitude,\n            longitude,\n            count(*) AS request_count\n        FROM ${table}\n        WHERE $__timeFilter(timestamp)\n        GROUP BY latitude, longitude\n    )\n)\nORDER BY percentage_band",
+            "refId": "Geo as Percentages"
+          }
+        ],
+        "title": "Traffic Location Geo",
+        "transparent": true,
+        "type": "geomap"
+      }
+    },
+    "becxq7ho7bmyod": {
+      "name": "Zuplo: Traffic Distribution (Colo/IATA)",
+      "uid": "becxq7ho7bmyod",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The distribution of request traffic on each colo node using their IATA designation",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "displayLabels": [],
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true,
+            "values": [
+              "percent",
+              "value"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "/^percentage$/",
+            "limit": 10,
+            "values": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    colo AS colo_with_percentage,\n    count(*) AS request_count,\n    (count(*) * 100) / (SELECT count(*) FROM \"sbxzuplotwist\".\"zuplotest\" WHERE $__timeFilter(timestamp)) AS percentage\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY colo\nORDER BY request_count DESC",
+            "refId": "A"
+          }
+        ],
+        "title": "Traffic Distribution (Colo/IATA)",
+        "transparent": true,
+        "type": "piechart"
+      }
+    },
+    "eecxq6tlm1se8e": {
+      "name": "Zuplo: Current Most Active Timezones",
+      "uid": "eecxq6tlm1se8e",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST-FOR-LIBRARY-PANEL}"
+        },
+        "description": "Which timezone is the most active in terms of requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "libraryPanel": {
+          "name": "Zuplo: Current Most Active Timezones",
+          "uid": "eecxq6tlm1se8e"
+        },
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "pieType": "donut",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    timezone,\n    (count(*) * 100) / (SELECT count(*) FROM \"sbxzuplotwist\".\"zuplotest\" WHERE $__timeFilter(timestamp)) AS percentage\nFROM \"sbxzuplotwist\".\"zuplotest\"\nWHERE $__timeFilter(timestamp)\nGROUP BY timezone\nORDER BY percentage DESC\nLIMIT 5",
+            "refId": "A"
+          }
+        ],
+        "title": "Current Most Active Timezones",
+        "transparent": true,
+        "type": "piechart"
+      }
+    },
+    "fecxq5iaecykgb": {
+      "name": "Zuplo: Requests by Colo/IATA (Top 20) (Map)",
+      "uid": "fecxq5iaecykgb",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The colocation node that requests are hitting",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "showLegend": true,
+                "style": {
+                  "color": {
+                    "fixed": "#ff00db"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "request_count",
+                    "fixed": 5,
+                    "max": 50,
+                    "min": 5
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "text": {
+                    "fixed": "",
+                    "mode": "field"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "A"
+              },
+              "location": {
+                "gazetteer": "public/gazetteer/airports.geojson",
+                "lookup": "colo",
+                "mode": "lookup"
+              },
+              "name": "COLO/IATA",
+              "tooltip": true,
+              "type": "markers"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "coords",
+            "lat": 16.45913,
+            "lon": 25.699299,
+            "zoom": 1.53
+          }
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    colo,\n    count(*) AS request_count\nFROM (\n    SELECT\n        colo,\n        *\n    FROM ${table}\n)\nWHERE $__timeFilter(timestamp)\nGROUP BY colo\nORDER BY request_count DESC\nLIMIT 20",
+            "refId": "A"
+          }
+        ],
+        "title": "Requests by Colo/IATA (Top 20)",
+        "transparent": true,
+        "type": "geomap"
+      }
+    },
+    "decxq6bkoxekgf": {
+      "name": "Zuplo: Top 10 Locations",
+      "uid": "decxq6bkoxekgf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": true,
+            "mappings": [],
+            "noValue": "N/A",
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.2,
+          "barWidth": 1,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "normal",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "city",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": "The query is not a select statement.",
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": "The query is not a select statement."
+            },
+            "pluginVersion": "4.0.6",
+            "rawSql": "SELECT\n    city,\n    count(*) AS request_count\nFROM (\n    SELECT\n        city,  -- Assuming you have a 'city' column in your table\n        *\n    FROM ${table}\n)\nWHERE $__timeFilter(timestamp)\nGROUP BY city\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Locations",
+        "transparent": true,
+        "type": "barchart"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "4.0.6"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "The geographic spread of traffic",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 16,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "libraryPanel": {
+        "uid": "fecxq41xxgni8a",
+        "name": "Zuplo: Traffic Location Geo (Percentage)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 10,
+      "libraryPanel": {
+        "uid": "becxq7ho7bmyod",
+        "name": "Zuplo: Traffic Distribution (Colo/IATA)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 8,
+      "libraryPanel": {
+        "uid": "eecxq6tlm1se8e",
+        "name": "Zuplo: Current Most Active Timezones"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "libraryPanel": {
+        "uid": "fecxq5iaecykgb",
+        "name": "Zuplo: Requests by Colo/IATA (Top 20) (Map)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 4,
+      "libraryPanel": {
+        "uid": "decxq6bkoxekgf",
+        "name": "Zuplo: Top 10 Locations"
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "description": "",
+        "hide": 2,
+        "label": "Table",
+        "name": "table",
+        "query": "${VAR_TABLE}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TABLE}",
+          "text": "${VAR_TABLE}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TABLE}",
+            "text": "${VAR_TABLE}",
+            "selected": false
+          }
+        ]
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Zuplo Geo Distribution",
+  "uid": "fecy31jnf0dmoa",
+  "version": 3,
+  "weekStart": ""
+}

--- a/zuplo/grafana-dashboards/zuplo-high-level.json
+++ b/zuplo/grafana-dashboards/zuplo-high-level.json
@@ -1,0 +1,559 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_HYDROLIX_- SBXZUPLOTWIST",
+      "label": "Hydrolix - sbxzuplotwist",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    },
+    {
+      "name": "VAR_TABLE",
+      "type": "constant",
+      "label": "Table",
+      "value": "sbxzuplotwist.zuplotest",
+      "description": ""
+    }
+  ],
+  "__elements": {
+    "fecxpuv0un9xcc": {
+      "name": "Zuplo: Geographic Request Distribution Heatmap",
+      "uid": "fecxpuv0un9xcc",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Overview of where traffic to your API originates",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "opacity": 0.8,
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "nightColor": "#a7a6ba4D",
+                "show": "to",
+                "sun": false
+              },
+              "name": "Night/Day",
+              "opacity": 0.4,
+              "tooltip": true,
+              "type": "dayNight"
+            },
+            {
+              "config": {
+                "blur": 10,
+                "radius": 8,
+                "weight": {
+                  "fixed": 1,
+                  "max": 1,
+                  "min": 0
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "Geographic Requests"
+              },
+              "location": {
+                "lookup": "country",
+                "mode": "lookup"
+              },
+              "name": "Requesting Geo",
+              "opacity": 0.5,
+              "tooltip": true,
+              "type": "heatmap"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "coords",
+            "lat": 16.07157,
+            "lon": 14.310928,
+            "zoom": 1.72
+          }
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "country",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "country"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "requests",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "country",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "country"
+                ],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT country, count(requestId) as requests FROM ${table} WHERE $__timeFilter(timestamp) GROUP BY country LIMIT 1000",
+            "refId": "Geographic Requests"
+          }
+        ],
+        "title": "Geographic Request Distribution",
+        "transparent": true,
+        "type": "geomap"
+      }
+    },
+    "cecxpwfex4ikgc": {
+      "name": "Zuplo Total Request Volume (Single Metric)",
+      "uid": "cecxpwfex4ikgc",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The total number of requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#ff00bd",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "center",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "total_requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "total_requests",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    count(requestId) AS total_requests\nFROM ${table}\nWHERE $__timeFilter(timestamp)",
+            "refId": "A"
+          }
+        ],
+        "title": "Total Requests",
+        "transparent": true,
+        "type": "stat"
+      }
+    },
+    "aecxpx1wf7wn4f": {
+      "name": "Zuplo: Requests Per Day (Fixed 14 Days)",
+      "uid": "aecxpx1wf7wn4f",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The total number of API requests per day (default time range is 14 days)",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "opacity",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#ff00bd",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.1,
+          "barWidth": 0.1,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "vertical",
+          "showValue": "auto",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "date",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toDate(timestamp) AS date,  -- Extract the date part\n    count(*) AS daily_requests   -- Count requests for each day\nFROM ${table}\nWHERE timestamp >= toDateTime(now() - INTERVAL 14 DAY) AND timestamp <= toDateTime(now()) -- customized to used fixed values\nGROUP BY date                   -- Group by date\nORDER BY date ASC              -- Order by date",
+            "refId": "A"
+          }
+        ],
+        "title": "Requests Per Day (Fixed 14 Days)",
+        "transparent": true,
+        "type": "barchart"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "4.0.6"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Request distribution heatmap, total request volume in the time period, and the total requests made in the past 14 days broken down by day.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "libraryPanel": {
+        "uid": "fecxpuv0un9xcc",
+        "name": "Zuplo: Geographic Request Distribution Heatmap"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 4,
+      "libraryPanel": {
+        "uid": "cecxpwfex4ikgc",
+        "name": "Zuplo Total Request Volume (Single Metric)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 6,
+      "libraryPanel": {
+        "uid": "aecxpx1wf7wn4f",
+        "name": "Zuplo: Requests Per Day (Fixed 14 Days)"
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Hydrolix - sbxzuplotwist",
+          "value": "de5x84pgij7r4a"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "selected_data_source",
+        "options": [],
+        "query": "grafana-clickhouse-datasource",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "hide": 2,
+        "label": "Table",
+        "name": "table",
+        "query": "${VAR_TABLE}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TABLE}",
+          "text": "${VAR_TABLE}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TABLE}",
+            "text": "${VAR_TABLE}",
+            "selected": false
+          }
+        ]
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Zuplo High Level",
+  "uid": "fecy1npaaf6dcd",
+  "version": 3,
+  "weekStart": ""
+}

--- a/zuplo/grafana-dashboards/zuplo-main-dashboard.json
+++ b/zuplo/grafana-dashboards/zuplo-main-dashboard.json
@@ -1,0 +1,2719 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_HYDROLIX_- SBXZUPLOTWIST",
+      "label": "Hydrolix - sbxzuplotwist",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    },
+    {
+      "name": "DS_HYDROLIX_- SBXZUPLOTWIST-FOR-LIBRARY-PANEL",
+      "label": "Hydrolix - sbxzuplotwist",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse",
+      "usage": {
+        "libraryPanels": [
+          {
+            "name": "Zuplo: Current Most Active Timezones",
+            "uid": "eecxq6tlm1se8e"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VAR_TABLE",
+      "type": "constant",
+      "label": "Table",
+      "value": "sbxzuplotwist.zuplotest",
+      "description": ""
+    }
+  ],
+  "__elements": {
+    "fecxpuv0un9xcc": {
+      "name": "Zuplo: Geographic Request Distribution Heatmap",
+      "uid": "fecxpuv0un9xcc",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Overview of where traffic to your API originates",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "opacity": 0.8,
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "nightColor": "#a7a6ba4D",
+                "show": "to",
+                "sun": false
+              },
+              "name": "Night/Day",
+              "opacity": 0.4,
+              "tooltip": true,
+              "type": "dayNight"
+            },
+            {
+              "config": {
+                "blur": 10,
+                "radius": 8,
+                "weight": {
+                  "fixed": 1,
+                  "max": 1,
+                  "min": 0
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "Geographic Requests"
+              },
+              "location": {
+                "lookup": "country",
+                "mode": "lookup"
+              },
+              "name": "Requesting Geo",
+              "opacity": 0.5,
+              "tooltip": true,
+              "type": "heatmap"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "coords",
+            "lat": 16.07157,
+            "lon": 14.310928,
+            "zoom": 1.72
+          }
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "country",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "country"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "requests",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "country",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "country"
+                ],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT country, count(requestId) as requests FROM ${table} WHERE $__timeFilter(timestamp) GROUP BY country LIMIT 1000",
+            "refId": "Geographic Requests"
+          }
+        ],
+        "title": "Geographic Request Distribution",
+        "transparent": true,
+        "type": "geomap"
+      }
+    },
+    "cecxpwfex4ikgc": {
+      "name": "Zuplo Total Request Volume (Single Metric)",
+      "uid": "cecxpwfex4ikgc",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The total number of requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#ff00bd",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "center",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "total_requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "total_requests",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    count(requestId) AS total_requests\nFROM ${table}\nWHERE $__timeFilter(timestamp)",
+            "refId": "A"
+          }
+        ],
+        "title": "Total Requests",
+        "transparent": true,
+        "type": "stat"
+      }
+    },
+    "aecxpx1wf7wn4f": {
+      "name": "Zuplo: Requests Per Day (Fixed 14 Days)",
+      "uid": "aecxpx1wf7wn4f",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The total number of API requests per day (default time range is 14 days)",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "opacity",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#ff00bd",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.1,
+          "barWidth": 0.1,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "vertical",
+          "showValue": "auto",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "date",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toDate(timestamp) AS date,  -- Extract the date part\n    count(*) AS daily_requests   -- Count requests for each day\nFROM ${table}\nWHERE timestamp >= toDateTime(now() - INTERVAL 14 DAY) AND timestamp <= toDateTime(now()) -- customized to used fixed values\nGROUP BY date                   -- Group by date\nORDER BY date ASC              -- Order by date",
+            "refId": "A"
+          }
+        ],
+        "title": "Requests Per Day (Fixed 14 Days)",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "becxpxy81f3eod": {
+      "name": "Zuplo: Request Response Time",
+      "uid": "becxpxy81f3eod",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Request response times as Median, Average and P95",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time, -- Time bucket (adjust as needed)\n    quantile(0.5)(durationMs) AS median_duration,\n    avg(durationMs) AS average_duration,\n    quantile(0.95)(durationMs) AS p95_duration\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY time\nORDER BY time ASC",
+            "refId": "Request Times"
+          }
+        ],
+        "title": "Request Response Time",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "cecxpyk5wt7nkf": {
+      "name": "Zuplo: Top 20 Requests by Route Path",
+      "uid": "cecxpyk5wt7nkf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The top 10 routes that demand the most trafic.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "mode": "lcd",
+                "type": "gauge",
+                "valueDisplayMode": "text"
+              },
+              "filterable": true,
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#ff00bd",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "enablePagination": true,
+            "fields": [],
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [],
+                "columns": [],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [],
+                "limit": 1000,
+                "meta": {},
+                "mode": "list",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    routePath,\n    count(*) AS request_count\nFROM ${table}\nWHERE $__timeFilter(timestamp)  -- Grafana time filter (essential)\nGROUP BY routePath\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Routes by Request Count",
+        "transparent": true,
+        "type": "table"
+      }
+    },
+    "decxpz3jy0g74d": {
+      "name": "Zuplo: Total Request Distribution by Method",
+      "uid": "decxpz3jy0g74d",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Overall view of the proportion of different HTTP methods in use.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": []
+          },
+          "overrides": []
+        },
+        "options": {
+          "displayLabels": [
+            "name",
+            "percent"
+          ],
+          "legend": {
+            "displayMode": "list",
+            "placement": "right",
+            "showLegend": true,
+            "values": [
+              "percent"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "method_requests",
+                  "column": "method"
+                }
+              ],
+              "columns": [
+                {
+                  "name": "method"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "groupBy": [
+                "method"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "method_requests",
+                    "column": "method"
+                  }
+                ],
+                "columns": [
+                  {
+                    "name": "method"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "groupBy": [
+                  "method"
+                ],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT method, count(method) as method_requests FROM ${table} WHERE $__timeFilter(timestamp) GROUP BY method LIMIT 1000\n\n",
+            "refId": "A"
+          }
+        ],
+        "title": "Total Request Distribution by Method",
+        "transparent": true,
+        "type": "piechart"
+      }
+    },
+    "becxpzp3ghkw0f": {
+      "name": "Zuplo: Average API Request Duration",
+      "uid": "becxpzp3ghkw0f",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Overview of the average request durations",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "smooth",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean"
+            ],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "avg",
+                  "alias": "Request_Duration",
+                  "column": "durationMs"
+                }
+              ],
+              "columns": [
+                {
+                  "hint": "time",
+                  "name": "timestamp",
+                  "type": "DateTime64(3)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [
+                {
+                  "condition": "AND",
+                  "filterType": "custom",
+                  "hint": "time",
+                  "key": "",
+                  "operator": "WITH IN DASHBOARD TIME RANGE",
+                  "type": "datetime"
+                }
+              ],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "trend",
+              "orderBy": [
+                {
+                  "default": true,
+                  "dir": "ASC",
+                  "hint": "time",
+                  "name": ""
+                }
+              ],
+              "queryType": "timeseries",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 0,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "avg",
+                    "alias": "Request_Duration",
+                    "column": "durationMs"
+                  }
+                ],
+                "columns": [
+                  {
+                    "hint": "time",
+                    "name": "timestamp",
+                    "type": "DateTime64(3)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [
+                  {
+                    "condition": "AND",
+                    "filterType": "custom",
+                    "hint": "time",
+                    "key": "",
+                    "operator": "WITH IN DASHBOARD TIME RANGE",
+                    "type": "datetime"
+                  }
+                ],
+                "groupBy": [],
+                "limit": 1000,
+                "meta": {},
+                "mode": "trend",
+                "orderBy": [
+                  {
+                    "default": true,
+                    "dir": "ASC",
+                    "hint": "time",
+                    "name": ""
+                  }
+                ],
+                "queryType": "timeseries",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "timeseries",
+            "rawSql": "SELECT $__timeInterval(timestamp) as time, avg(durationMs) as Request_Duration FROM ${table} WHERE ( time >= $__fromTime AND time <= $__toTime ) GROUP BY time ORDER BY time ASC LIMIT 1000",
+            "refId": "A"
+          }
+        ],
+        "title": "Average API Request Duration",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "cecxq0dtk8ao0c": {
+      "name": "Zuplo: Top Requesting IP Addresses",
+      "uid": "cecxq0dtk8ao0c",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The IP Addresses that are making the most requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.5,
+          "barWidth": 0.62,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "never",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "clientIP",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "request_count",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "clientIP",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "clientIP",
+                "requestId"
+              ],
+              "limit": 10,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [
+                {
+                  "dir": "DESC",
+                  "name": "request_count"
+                }
+              ],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "request_count",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "clientIP",
+                    "type": "Nullable(String)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "clientIP",
+                  "requestId"
+                ],
+                "limit": 10,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [
+                  {
+                    "dir": "DESC",
+                    "name": "request_count"
+                  }
+                ],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT clientIP, requestId, count(requestId) as request_count FROM ${table} GROUP BY clientIP, requestId ORDER BY request_count DESC LIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Requesting IP Addresses",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "decxq1bd5pukgf": {
+      "name": "Zuplo: Percentage of Requests Rate Limited (Gauge)",
+      "uid": "decxq1bd5pukgf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "What percentage of requests are subject to a 429",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 2,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "options": {
+          "minVizHeight": 75,
+          "minVizWidth": 75,
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "/^rate_limited_percentage$/",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "sizing": "auto"
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    (COUNT(CASE WHEN statusCode = 429 THEN 1 END) * 100) / COUNT(*) AS rate_limited_percentage\nFROM ${table}\nWHERE $__timeFilter(timestamp)",
+            "refId": "A"
+          }
+        ],
+        "title": "Percentage of Requests Rate Limited",
+        "transparent": true,
+        "type": "gauge"
+      }
+    },
+    "aecxq1x4kveo0a": {
+      "name": "Zuplo: Requests by Status Code",
+      "uid": "aecxq1x4kveo0a",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "How many requests are being processed of what HTTP status code",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 3,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "always",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "Code",
+                  "column": "statusCode"
+                },
+                {
+                  "aggregateType": "count",
+                  "alias": "requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "statusCode",
+                  "type": "Nullable(Int32)"
+                },
+                {
+                  "custom": false,
+                  "name": "timestamp",
+                  "type": "DateTime64(3)"
+                },
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "timestamp",
+                "requestId",
+                "statusCode"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "Code",
+                    "column": "statusCode"
+                  },
+                  {
+                    "aggregateType": "count",
+                    "alias": "requests",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "statusCode",
+                    "type": "Nullable(Int32)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "timestamp",
+                    "type": "DateTime64(3)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "timestamp",
+                  "requestId",
+                  "statusCode"
+                ],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time,\n    CASE WHEN statusCode = 200 THEN count(*) ELSE 0 END AS \"200\",  -- Success\n    CASE WHEN statusCode = 400 THEN count(*) ELSE 0 END AS \"400\",  -- Bad Request\n    CASE WHEN statusCode = 401 THEN count(*) ELSE 0 END AS \"401\",  -- Unauthorized\n    CASE WHEN statusCode = 403 THEN count(*) ELSE 0 END AS \"403\",  -- Forbidden\n    CASE WHEN statusCode = 404 THEN count(*) ELSE 0 END AS \"404\",  -- Not Found\n    CASE WHEN statusCode = 429 THEN count(*) ELSE 0 END AS \"429\",  -- Too Many Requests (Rate Limiting)\n    CASE WHEN statusCode = 500 THEN count(*) ELSE 0 END AS \"500\",  -- Internal Server Error\n    CASE WHEN statusCode = 502 THEN count(*) ELSE 0 END AS \"502\",  -- Bad Gateway\n    CASE WHEN statusCode = 503 THEN count(*) ELSE 0 END AS \"503\",  -- Service Unavailable\n    CASE WHEN statusCode = 504 THEN count(*) ELSE 0 END AS \"504\"   -- Gateway Timeout\nFROM ${table}\nWHERE $__timeFilter(timestamp)  -- Important for Grafana time range\nGROUP BY time, statusCode\nORDER BY time ASC",
+            "refId": "Requests by Status Code"
+          }
+        ],
+        "title": "Requests by Status Code",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "aecxq2m1ju2o0e": {
+      "name": "Zuplo: Percentage of Requests Unauthorized (401) (Gauge)",
+      "uid": "aecxq2m1ju2o0e",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "What percentage of requests are being made by unauthorized clients",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 2,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "options": {
+          "minVizHeight": 75,
+          "minVizWidth": 75,
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "/^unauthorized_percentage$/",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "sizing": "auto"
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    (COUNT(CASE WHEN statusCode = 401 THEN 1 END) * 100) / COUNT(*) AS unauthorized_percentage\nFROM ${table}\nWHERE $__timeFilter(timestamp)",
+            "refId": "A"
+          }
+        ],
+        "title": "Percentage of Requests Unauthorized (401)",
+        "transparent": true,
+        "type": "gauge"
+      }
+    },
+    "fecxq36cgp728d": {
+      "name": "Zuplo: Error Rates",
+      "uid": "fecxq36cgp728d",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "How many HTTP status errors between 40x and 50x are being seen",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Requests",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 400
+                },
+                {
+                  "color": "red",
+                  "value": 500
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [
+                {
+                  "alias": "time",
+                  "hint": "time",
+                  "name": "timestamp",
+                  "type": "datetime"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "time"
+              ],
+              "meta": {},
+              "mode": "list",
+              "orderBy": [
+                {
+                  "dir": "ASC",
+                  "name": "time"
+                }
+              ],
+              "queryType": "timeseries",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [],
+                "columns": [
+                  {
+                    "alias": "time",
+                    "hint": "time",
+                    "name": "timestamp",
+                    "type": "datetime"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "time"
+                ],
+                "meta": {},
+                "mode": "list",
+                "orderBy": [
+                  {
+                    "dir": "ASC",
+                    "name": "time"
+                  }
+                ],
+                "queryType": "timeseries",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time,\n    CASE\n        WHEN statusCode = 400 THEN count(*)  -- Count 400 errors\n        ELSE 0                               -- Other status codes\n    END AS \"400\",  -- Alias for 400 errors\n    CASE\n        WHEN statusCode = 401 THEN count(*)  -- Count 401 errors\n        ELSE 0\n    END AS \"401\",  -- Alias for 401 errors\n    --... Add similar CASE statements for other status codes...\n    CASE\n        WHEN statusCode = 500 THEN count(*)  -- Count 500 errors\n        ELSE 0\n    END AS \"500\"   -- Alias for 500 errors\nFROM ${table}\nWHERE $__timeFilter(timestamp) AND statusCode BETWEEN 400 AND 599\nGROUP BY time, statusCode\nORDER BY time ASC",
+            "refId": "Error Rates"
+          }
+        ],
+        "title": "Error Rates",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "fecxq41xxgni8a": {
+      "name": "Zuplo: Traffic Location Geo (Percentage)",
+      "uid": "fecxq41xxgni8a",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The geographic location of API requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#6ED0E0",
+                  "value": 5
+                },
+                {
+                  "color": "#EF843C",
+                  "value": 10
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 20
+                },
+                {
+                  "color": "#447EBC",
+                  "value": 30
+                },
+                {
+                  "color": "#CCA300",
+                  "value": 40
+                },
+                {
+                  "color": "#508642",
+                  "value": 50
+                },
+                {
+                  "color": "#705DA0",
+                  "value": 60
+                },
+                {
+                  "color": "#BA43A9",
+                  "value": 70
+                },
+                {
+                  "color": "#1F78C1",
+                  "value": 80
+                },
+                {
+                  "color": "#E24D42",
+                  "value": 90
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": true,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "nightColor": "#a7a6ba4D",
+                "show": "to",
+                "sun": false
+              },
+              "name": "Night/Day",
+              "opacity": 0.4,
+              "tooltip": true,
+              "type": "dayNight"
+            },
+            {
+              "config": {
+                "showLegend": true,
+                "style": {
+                  "color": {
+                    "field": "percentage_band",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "percentage",
+                    "fixed": 5,
+                    "max": 20,
+                    "min": 1
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "text": {
+                    "field": "percentage_band",
+                    "fixed": "",
+                    "mode": "fixed"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "Geo as Percentages"
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "Location",
+              "tooltip": true,
+              "type": "markers"
+            }
+          ],
+          "tooltip": {
+            "mode": "none"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "coords",
+            "lat": 12.0028,
+            "lon": 11.636296,
+            "zoom": 2
+          }
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    latitude,\n    longitude,\n    CASE\n        WHEN percentage < 5 THEN 1  -- Band 1\n        WHEN percentage >= 5 AND percentage < 10 THEN 2  -- Band 2\n        WHEN percentage >= 10 AND percentage < 20 THEN 3  -- Band 3\n        WHEN percentage >= 20 AND percentage < 30 THEN 4  -- Band 4\n        WHEN percentage >= 30 AND percentage < 40 THEN 5  -- Band 5\n        WHEN percentage >= 40 AND percentage < 50 THEN 6  -- Band 6\n        WHEN percentage >= 50 AND percentage < 60 THEN 7  -- Band 7\n        WHEN percentage >= 60 AND percentage < 70 THEN 8  -- Band 8\n        WHEN percentage >= 70 AND percentage < 80 THEN 9  -- Band 9\n        WHEN percentage >= 80 AND percentage < 90 THEN 10  -- Band 10\n        WHEN percentage >= 90 AND percentage <= 100 THEN 11  -- Band 9\n        ELSE 0  -- Default (shouldn't happen)\n    END AS percentage_band, percentage\nFROM (\n    SELECT\n        latitude,\n        longitude,\n        ROUND((request_count / sum(request_count) OVER ()) * 100, 2) AS percentage  -- Round to 2 decimal places\n    FROM (\n        SELECT\n            latitude,\n            longitude,\n            count(*) AS request_count\n        FROM ${table}\n        WHERE $__timeFilter(timestamp)\n        GROUP BY latitude, longitude\n    )\n)\nORDER BY percentage_band",
+            "refId": "Geo as Percentages"
+          }
+        ],
+        "title": "Traffic Location Geo",
+        "transparent": true,
+        "type": "geomap"
+      }
+    },
+    "fecxq5iaecykgb": {
+      "name": "Zuplo: Requests by Colo/IATA (Top 20) (Map)",
+      "uid": "fecxq5iaecykgb",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The colocation node that requests are hitting",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Layer 0",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "showLegend": true,
+                "style": {
+                  "color": {
+                    "fixed": "#ff00db"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "field": "request_count",
+                    "fixed": 5,
+                    "max": 50,
+                    "min": 5
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "symbolAlign": {
+                    "horizontal": "center",
+                    "vertical": "center"
+                  },
+                  "text": {
+                    "fixed": "",
+                    "mode": "field"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "filterData": {
+                "id": "byRefId",
+                "options": "A"
+              },
+              "location": {
+                "gazetteer": "public/gazetteer/airports.geojson",
+                "lookup": "colo",
+                "mode": "lookup"
+              },
+              "name": "COLO/IATA",
+              "tooltip": true,
+              "type": "markers"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "coords",
+            "lat": 16.45913,
+            "lon": 25.699299,
+            "zoom": 1.53
+          }
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    colo,\n    count(*) AS request_count\nFROM (\n    SELECT\n        colo,\n        *\n    FROM ${table}\n)\nWHERE $__timeFilter(timestamp)\nGROUP BY colo\nORDER BY request_count DESC\nLIMIT 20",
+            "refId": "A"
+          }
+        ],
+        "title": "Requests by Colo/IATA (Top 20)",
+        "transparent": true,
+        "type": "geomap"
+      }
+    },
+    "decxq6bkoxekgf": {
+      "name": "Zuplo: Top 10 Locations",
+      "uid": "decxq6bkoxekgf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": true,
+            "mappings": [],
+            "noValue": "N/A",
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.2,
+          "barWidth": 1,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "normal",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "city",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": "The query is not a select statement.",
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": "The query is not a select statement."
+            },
+            "pluginVersion": "4.0.6",
+            "rawSql": "SELECT\n    city,\n    count(*) AS request_count\nFROM (\n    SELECT\n        city,  -- Assuming you have a 'city' column in your table\n        *\n    FROM ${table}\n)\nWHERE $__timeFilter(timestamp)\nGROUP BY city\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Locations",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "eecxq6tlm1se8e": {
+      "name": "Zuplo: Current Most Active Timezones",
+      "uid": "eecxq6tlm1se8e",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST-FOR-LIBRARY-PANEL}"
+        },
+        "description": "Which timezone is the most active in terms of requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "libraryPanel": {
+          "name": "Zuplo: Current Most Active Timezones",
+          "uid": "eecxq6tlm1se8e"
+        },
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "pieType": "donut",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    timezone,\n    (count(*) * 100) / (SELECT count(*) FROM \"sbxzuplotwist\".\"zuplotest\" WHERE $__timeFilter(timestamp)) AS percentage\nFROM \"sbxzuplotwist\".\"zuplotest\"\nWHERE $__timeFilter(timestamp)\nGROUP BY timezone\nORDER BY percentage DESC\nLIMIT 5",
+            "refId": "A"
+          }
+        ],
+        "title": "Current Most Active Timezones",
+        "transparent": true,
+        "type": "piechart"
+      }
+    },
+    "becxq7ho7bmyod": {
+      "name": "Zuplo: Traffic Distribution (Colo/IATA)",
+      "uid": "becxq7ho7bmyod",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The distribution of request traffic on each colo node using their IATA designation",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "displayLabels": [],
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true,
+            "values": [
+              "percent",
+              "value"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "/^percentage$/",
+            "limit": 10,
+            "values": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    colo AS colo_with_percentage,\n    count(*) AS request_count,\n    (count(*) * 100) / (SELECT count(*) FROM \"sbxzuplotwist\".\"zuplotest\" WHERE $__timeFilter(timestamp)) AS percentage\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY colo\nORDER BY request_count DESC",
+            "refId": "A"
+          }
+        ],
+        "title": "Traffic Distribution (Colo/IATA)",
+        "transparent": true,
+        "type": "piechart"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "4.0.6"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Everything available, all in one place!",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "libraryPanel": {
+        "uid": "fecxpuv0un9xcc",
+        "name": "Zuplo: Geographic Request Distribution Heatmap"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 9,
+      "libraryPanel": {
+        "uid": "cecxpwfex4ikgc",
+        "name": "Zuplo Total Request Volume (Single Metric)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 11,
+      "libraryPanel": {
+        "uid": "aecxpx1wf7wn4f",
+        "name": "Zuplo: Requests Per Day (Fixed 14 Days)"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Request Summaries",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "fieldMinMax": true,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 100
+              },
+              {
+                "color": "#EAB839",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT\n    time,\n    requests / (toUInt64(time) - toUInt64(neighbor(time, -1, toDateTime64(0, 3)))) AS rps  -- Corrected type handling\nFROM (\n    SELECT\n        toStartOfSecond(timestamp) AS time,  -- Time bucket (adjust as needed)\n        count(*) AS requests\n    FROM \"sbxzuplotwist\".\"zuplotest\"\n    WHERE $__timeFilter(timestamp)\n    GROUP BY time\n    ORDER BY time ASC\n)",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Per Second",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 19,
+      "libraryPanel": {
+        "uid": "becxpxy81f3eod",
+        "name": "Zuplo: Request Response Time"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 12,
+      "libraryPanel": {
+        "uid": "cecxpyk5wt7nkf",
+        "name": "Zuplo: Top 20 Requests by Route Path"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 3,
+      "libraryPanel": {
+        "uid": "decxpz3jy0g74d",
+        "name": "Zuplo: Total Request Distribution by Method"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 2,
+      "libraryPanel": {
+        "uid": "becxpzp3ghkw0f",
+        "name": "Zuplo: Average API Request Duration"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 7,
+      "libraryPanel": {
+        "uid": "cecxq0dtk8ao0c",
+        "name": "Zuplo: Top Requesting IP Addresses"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Status Codes & Error Rates",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 9,
+        "w": 7,
+        "x": 0,
+        "y": 45
+      },
+      "id": 17,
+      "libraryPanel": {
+        "uid": "decxq1bd5pukgf",
+        "name": "Zuplo: Percentage of Requests Rate Limited (Gauge)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 9,
+        "w": 17,
+        "x": 7,
+        "y": 45
+      },
+      "id": 8,
+      "libraryPanel": {
+        "uid": "aecxq1x4kveo0a",
+        "name": "Zuplo: Requests by Status Code"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 54
+      },
+      "id": 18,
+      "libraryPanel": {
+        "uid": "aecxq2m1ju2o0e",
+        "name": "Zuplo: Percentage of Requests Unauthorized (401) (Gauge)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 17,
+        "x": 7,
+        "y": 54
+      },
+      "id": 4,
+      "libraryPanel": {
+        "uid": "fecxq36cgp728d",
+        "name": "Zuplo: Error Rates"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Geo",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 13,
+      "libraryPanel": {
+        "uid": "fecxq41xxgni8a",
+        "name": "Zuplo: Traffic Location Geo (Percentage)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 0,
+        "y": 75
+      },
+      "id": 22,
+      "libraryPanel": {
+        "uid": "fecxq5iaecykgb",
+        "name": "Zuplo: Requests by Colo/IATA (Top 20) (Map)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 15,
+        "w": 10,
+        "x": 14,
+        "y": 75
+      },
+      "id": 20,
+      "libraryPanel": {
+        "uid": "decxq6bkoxekgf",
+        "name": "Zuplo: Top 10 Locations"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 83
+      },
+      "id": 23,
+      "libraryPanel": {
+        "uid": "eecxq6tlm1se8e",
+        "name": "Zuplo: Current Most Active Timezones"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 6,
+        "y": 83
+      },
+      "id": 21,
+      "libraryPanel": {
+        "uid": "becxq7ho7bmyod",
+        "name": "Zuplo: Traffic Distribution (Colo/IATA)"
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Hydrolix - sbxzuplotwist",
+          "value": "de5x84pgij7r4a"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "selected_data_source",
+        "options": [],
+        "query": "grafana-clickhouse-datasource",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "description": "",
+        "hide": 2,
+        "label": "Table",
+        "name": "table",
+        "query": "${VAR_TABLE}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TABLE}",
+          "text": "${VAR_TABLE}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TABLE}",
+            "text": "${VAR_TABLE}",
+            "selected": false
+          }
+        ]
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Zuplo Main Dashboard",
+  "uid": "aecqkprbwhxj4a",
+  "version": 90,
+  "weekStart": ""
+}

--- a/zuplo/grafana-dashboards/zuplo-request-summaries.json
+++ b/zuplo/grafana-dashboards/zuplo-request-summaries.json
@@ -1,0 +1,1523 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_HYDROLIX_- SBXZUPLOTWIST",
+      "label": "Hydrolix - sbxzuplotwist",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    },
+    {
+      "name": "VAR_TABLE",
+      "type": "constant",
+      "label": "Table",
+      "value": "sbxzuplotwist.zuplotest",
+      "description": ""
+    }
+  ],
+  "__elements": {
+    "aecxq1x4kveo0a": {
+      "name": "Zuplo: Requests by Status Code",
+      "uid": "aecxq1x4kveo0a",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "How many requests are being processed of what HTTP status code",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 3,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "always",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "Code",
+                  "column": "statusCode"
+                },
+                {
+                  "aggregateType": "count",
+                  "alias": "requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "statusCode",
+                  "type": "Nullable(Int32)"
+                },
+                {
+                  "custom": false,
+                  "name": "timestamp",
+                  "type": "DateTime64(3)"
+                },
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "timestamp",
+                "requestId",
+                "statusCode"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "Code",
+                    "column": "statusCode"
+                  },
+                  {
+                    "aggregateType": "count",
+                    "alias": "requests",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "statusCode",
+                    "type": "Nullable(Int32)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "timestamp",
+                    "type": "DateTime64(3)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "timestamp",
+                  "requestId",
+                  "statusCode"
+                ],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time,\n    CASE WHEN statusCode = 200 THEN count(*) ELSE 0 END AS \"200\",  -- Success\n    CASE WHEN statusCode = 400 THEN count(*) ELSE 0 END AS \"400\",  -- Bad Request\n    CASE WHEN statusCode = 401 THEN count(*) ELSE 0 END AS \"401\",  -- Unauthorized\n    CASE WHEN statusCode = 403 THEN count(*) ELSE 0 END AS \"403\",  -- Forbidden\n    CASE WHEN statusCode = 404 THEN count(*) ELSE 0 END AS \"404\",  -- Not Found\n    CASE WHEN statusCode = 429 THEN count(*) ELSE 0 END AS \"429\",  -- Too Many Requests (Rate Limiting)\n    CASE WHEN statusCode = 500 THEN count(*) ELSE 0 END AS \"500\",  -- Internal Server Error\n    CASE WHEN statusCode = 502 THEN count(*) ELSE 0 END AS \"502\",  -- Bad Gateway\n    CASE WHEN statusCode = 503 THEN count(*) ELSE 0 END AS \"503\",  -- Service Unavailable\n    CASE WHEN statusCode = 504 THEN count(*) ELSE 0 END AS \"504\"   -- Gateway Timeout\nFROM ${table}\nWHERE $__timeFilter(timestamp)  -- Important for Grafana time range\nGROUP BY time, statusCode\nORDER BY time ASC",
+            "refId": "Requests by Status Code"
+          }
+        ],
+        "title": "Requests by Status Code",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "becxpxy81f3eod": {
+      "name": "Zuplo: Request Response Time",
+      "uid": "becxpxy81f3eod",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Request response times as Median, Average and P95",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time, -- Time bucket (adjust as needed)\n    quantile(0.5)(durationMs) AS median_duration,\n    avg(durationMs) AS average_duration,\n    quantile(0.95)(durationMs) AS p95_duration\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY time\nORDER BY time ASC",
+            "refId": "Request Times"
+          }
+        ],
+        "title": "Request Response Time",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "decy3bvqkkwzka": {
+      "name": "Zuplo: Top 10 Users",
+      "uid": "decy3bvqkkwzka",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "List of users (JWK sub) with the most requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": true
+            },
+            "mappings": [],
+            "noValue": "[anonymous]",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": [
+              "request_count"
+            ],
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": false
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    userSub,\n    count(*) AS request_count\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY userSub\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Users",
+        "transparent": true,
+        "type": "table"
+      }
+    },
+    "cecxpyk5wt7nkf": {
+      "name": "Zuplo: Top 10 Routes by Request Count",
+      "uid": "cecxpyk5wt7nkf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The top 10 routes that demand the most trafic.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "mode": "lcd",
+                "type": "gauge",
+                "valueDisplayMode": "text"
+              },
+              "filterable": true,
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#ff00bd",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "enablePagination": true,
+            "fields": [],
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [],
+                "columns": [],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [],
+                "limit": 1000,
+                "meta": {},
+                "mode": "list",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    routePath,\n    count(*) AS request_count\nFROM ${table}\nWHERE $__timeFilter(timestamp)  -- Grafana time filter (essential)\nGROUP BY routePath\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Routes by Request Count",
+        "transparent": true,
+        "type": "table"
+      }
+    },
+    "cecxq0dtk8ao0c": {
+      "name": "Zuplo: Top Requesting IP Addresses",
+      "uid": "cecxq0dtk8ao0c",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The IP Addresses that are making the most requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.5,
+          "barWidth": 0.62,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "never",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "clientIP",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "request_count",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "clientIP",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "clientIP",
+                "requestId"
+              ],
+              "limit": 10,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [
+                {
+                  "dir": "DESC",
+                  "name": "request_count"
+                }
+              ],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "request_count",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "clientIP",
+                    "type": "Nullable(String)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "clientIP",
+                  "requestId"
+                ],
+                "limit": 10,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [
+                  {
+                    "dir": "DESC",
+                    "name": "request_count"
+                  }
+                ],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT clientIP, requestId, count(requestId) as request_count FROM ${table} GROUP BY clientIP, requestId ORDER BY request_count DESC LIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Requesting IP Addresses",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "decxq6bkoxekgf": {
+      "name": "Zuplo: Top 10 Locations",
+      "uid": "decxq6bkoxekgf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": true,
+            "mappings": [],
+            "noValue": "N/A",
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.2,
+          "barWidth": 1,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "normal",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "city",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": "The query is not a select statement.",
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": "The query is not a select statement."
+            },
+            "pluginVersion": "4.0.6",
+            "rawSql": "SELECT\n    city,\n    count(*) AS request_count\nFROM (\n    SELECT\n        city,  -- Assuming you have a 'city' column in your table\n        *\n    FROM ${table}\n)\nWHERE $__timeFilter(timestamp)\nGROUP BY city\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Locations",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "aecy3csvo2yo0c": {
+      "name": "Zuplo: Top 10 Locations Response Time (Ms)",
+      "uid": "aecy3csvo2yo0c",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The top 10 requesting locations average reponse times",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "scheme",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "noValue": "[Unknown]",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 100
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 200
+                },
+                {
+                  "color": "#6ED0E0",
+                  "value": 300
+                },
+                {
+                  "color": "#EF843C",
+                  "value": 400
+                },
+                {
+                  "color": "#E24D42",
+                  "value": 500
+                },
+                {
+                  "color": "dark-red",
+                  "value": 600
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0,
+          "barWidth": 0.97,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    city,\n    avg(durationMs) AS average_duration_ms\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY city\nORDER BY count(*) DESC  -- Order by count without selecting it\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Locations Response Time (Ms)",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "eecy3dxm7gv0gb": {
+      "name": "Zuplo: Top 10 Users by Max RPS",
+      "uid": "eecy3dxm7gv0gb",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Top 10 Users by Max RPS",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "noValue": "[unknown]",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0,
+          "barWidth": 0.97,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "normal",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    userSub,\n    max(requests_per_second) AS max_rps\nFROM (\n    SELECT\n        userSub,\n        toStartOfSecond(timestamp) AS time_bucket,  -- 1-second intervals\n        count(*) / (toUInt64(toStartOfSecond(timestamp)) - toUInt64(neighbor(toStartOfSecond(timestamp), -1, toDateTime64(0, 3)))) AS requests_per_second\n    FROM ${table}\n    WHERE $__timeFilter(timestamp)\n    GROUP BY userSub, time_bucket\n)\nGROUP BY userSub\nORDER BY max_rps DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Users by Max RPS",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "decxywvz6jawwe": {
+      "name": "Zuplo: Top 10 Users by 429 Status Code",
+      "uid": "decxywvz6jawwe",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The top 10 users that have had the most 429 responses for their requests during the selected time period",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "noValue": "[unknown]",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0,
+          "barWidth": 0.97,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    userSub,\n    COUNT(CASE WHEN statusCode = 429 THEN 1 END) AS rate_limited_requests\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY userSub\nORDER BY rate_limited_requests DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Users by 429 Status Code",
+        "transparent": true,
+        "type": "barchart"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "4.0.6"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "The Grafana version of the analytics you find in the Zuplo Portal.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+      },
+      "description": "The total number of API requests over the selected time period",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "builderOptions": {
+            "aggregates": [
+              {
+                "aggregateType": "count",
+                "alias": "requests",
+                "column": "requestId"
+              }
+            ],
+            "columns": [
+              {
+                "custom": false,
+                "name": "requestId",
+                "type": "Nullable(String)"
+              },
+              {
+                "custom": false,
+                "name": "timestamp",
+                "type": "DateTime64(3)"
+              }
+            ],
+            "database": "sbxzuplotwist",
+            "filters": [],
+            "groupBy": [
+              "requestId",
+              "timestamp"
+            ],
+            "limit": 1000,
+            "meta": {},
+            "mode": "aggregate",
+            "orderBy": [
+              {
+                "dir": "ASC",
+                "name": "requestId"
+              }
+            ],
+            "queryType": "table",
+            "table": "zuplotest"
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "timestamp",
+                  "type": "DateTime64(3)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "requestId",
+                "timestamp"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [
+                {
+                  "dir": "ASC",
+                  "name": "requestId"
+                }
+              ],
+              "queryType": "table",
+              "table": "zuplotest"
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time,  -- Or toStartOfHour, toStartOfDay, etc. for different time granularities\n    count(*) AS total_requests\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY time\nORDER BY time ASC",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Requests",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 3,
+      "libraryPanel": {
+        "uid": "aecxq1x4kveo0a",
+        "name": "Zuplo: Requests by Status Code"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 5,
+      "libraryPanel": {
+        "uid": "becxpxy81f3eod",
+        "name": "Zuplo: Request Response Time"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Top 10",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 21
+      },
+      "id": 7,
+      "libraryPanel": {
+        "uid": "decy3bvqkkwzka",
+        "name": "Zuplo: Top 10 Users"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 7,
+        "y": 21
+      },
+      "id": 9,
+      "libraryPanel": {
+        "uid": "cecxpyk5wt7nkf",
+        "name": "Zuplo: Top 10 Routes by Request Count"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 21
+      },
+      "id": 11,
+      "libraryPanel": {
+        "uid": "cecxq0dtk8ao0c",
+        "name": "Zuplo: Top Requesting IP Addresses"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 13,
+      "libraryPanel": {
+        "uid": "decxq6bkoxekgf",
+        "name": "Zuplo: Top 10 Locations"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 14,
+      "libraryPanel": {
+        "uid": "aecy3csvo2yo0c",
+        "name": "Zuplo: Top 10 Locations Response Time (Ms)"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Rate Limiting",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 16,
+      "libraryPanel": {
+        "uid": "eecy3dxm7gv0gb",
+        "name": "Zuplo: Top 10 Users by Max RPS"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 17,
+      "libraryPanel": {
+        "uid": "decxywvz6jawwe",
+        "name": "Zuplo: Top 10 Users by 429 Status Code"
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Hydrolix - sbxzuplotwist",
+          "value": "de5x84pgij7r4a"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "selected_data_source",
+        "options": [],
+        "query": "grafana-clickhouse-datasource",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "description": "",
+        "hide": 2,
+        "label": "Table",
+        "name": "table",
+        "query": "${VAR_TABLE}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TABLE}",
+          "text": "${VAR_TABLE}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TABLE}",
+            "text": "${VAR_TABLE}",
+            "selected": false
+          }
+        ]
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Zuplo Standard Metrics - Grafana Version",
+  "uid": "becxrk017qgaof",
+  "version": 15,
+  "weekStart": ""
+}

--- a/zuplo/grafana-dashboards/zuplo-standard-metrics.json
+++ b/zuplo/grafana-dashboards/zuplo-standard-metrics.json
@@ -1,0 +1,1523 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_HYDROLIX_- SBXZUPLOTWIST",
+      "label": "Hydrolix - sbxzuplotwist",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    },
+    {
+      "name": "VAR_TABLE",
+      "type": "constant",
+      "label": "Table",
+      "value": "sbxzuplotwist.zuplotest",
+      "description": ""
+    }
+  ],
+  "__elements": {
+    "aecxq1x4kveo0a": {
+      "name": "Zuplo: Requests by Status Code",
+      "uid": "aecxq1x4kveo0a",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "How many requests are being processed of what HTTP status code",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 3,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "always",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "Code",
+                  "column": "statusCode"
+                },
+                {
+                  "aggregateType": "count",
+                  "alias": "requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "statusCode",
+                  "type": "Nullable(Int32)"
+                },
+                {
+                  "custom": false,
+                  "name": "timestamp",
+                  "type": "DateTime64(3)"
+                },
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "timestamp",
+                "requestId",
+                "statusCode"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "Code",
+                    "column": "statusCode"
+                  },
+                  {
+                    "aggregateType": "count",
+                    "alias": "requests",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "statusCode",
+                    "type": "Nullable(Int32)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "timestamp",
+                    "type": "DateTime64(3)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "timestamp",
+                  "requestId",
+                  "statusCode"
+                ],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time,\n    CASE WHEN statusCode = 200 THEN count(*) ELSE 0 END AS \"200\",  -- Success\n    CASE WHEN statusCode = 400 THEN count(*) ELSE 0 END AS \"400\",  -- Bad Request\n    CASE WHEN statusCode = 401 THEN count(*) ELSE 0 END AS \"401\",  -- Unauthorized\n    CASE WHEN statusCode = 403 THEN count(*) ELSE 0 END AS \"403\",  -- Forbidden\n    CASE WHEN statusCode = 404 THEN count(*) ELSE 0 END AS \"404\",  -- Not Found\n    CASE WHEN statusCode = 429 THEN count(*) ELSE 0 END AS \"429\",  -- Too Many Requests (Rate Limiting)\n    CASE WHEN statusCode = 500 THEN count(*) ELSE 0 END AS \"500\",  -- Internal Server Error\n    CASE WHEN statusCode = 502 THEN count(*) ELSE 0 END AS \"502\",  -- Bad Gateway\n    CASE WHEN statusCode = 503 THEN count(*) ELSE 0 END AS \"503\",  -- Service Unavailable\n    CASE WHEN statusCode = 504 THEN count(*) ELSE 0 END AS \"504\"   -- Gateway Timeout\nFROM ${table}\nWHERE $__timeFilter(timestamp)  -- Important for Grafana time range\nGROUP BY time, statusCode\nORDER BY time ASC",
+            "refId": "Requests by Status Code"
+          }
+        ],
+        "title": "Requests by Status Code",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "becxpxy81f3eod": {
+      "name": "Zuplo: Request Response Time",
+      "uid": "becxpxy81f3eod",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Request response times as Median, Average and P95",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time, -- Time bucket (adjust as needed)\n    quantile(0.5)(durationMs) AS median_duration,\n    avg(durationMs) AS average_duration,\n    quantile(0.95)(durationMs) AS p95_duration\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY time\nORDER BY time ASC",
+            "refId": "Request Times"
+          }
+        ],
+        "title": "Request Response Time",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "decy3bvqkkwzka": {
+      "name": "Zuplo: Top 10 Users",
+      "uid": "decy3bvqkkwzka",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "List of users (JWK sub) with the most requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": true
+            },
+            "mappings": [],
+            "noValue": "[anonymous]",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": [
+              "request_count"
+            ],
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": false
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    userSub,\n    count(*) AS request_count\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY userSub\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Users",
+        "transparent": true,
+        "type": "table"
+      }
+    },
+    "cecxpyk5wt7nkf": {
+      "name": "Zuplo: Top 10 Routes by Request Count",
+      "uid": "cecxpyk5wt7nkf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The top 10 routes that demand the most trafic.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "mode": "lcd",
+                "type": "gauge",
+                "valueDisplayMode": "text"
+              },
+              "filterable": true,
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#ff00bd",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "enablePagination": true,
+            "fields": [],
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [],
+              "limit": 1000,
+              "meta": {},
+              "mode": "list",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [],
+                "columns": [],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [],
+                "limit": 1000,
+                "meta": {},
+                "mode": "list",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    routePath,\n    count(*) AS request_count\nFROM ${table}\nWHERE $__timeFilter(timestamp)  -- Grafana time filter (essential)\nGROUP BY routePath\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Routes by Request Count",
+        "transparent": true,
+        "type": "table"
+      }
+    },
+    "cecxq0dtk8ao0c": {
+      "name": "Zuplo: Top Requesting IP Addresses",
+      "uid": "cecxq0dtk8ao0c",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The IP Addresses that are making the most requests",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.5,
+          "barWidth": 0.62,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "never",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "clientIP",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "request_count",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "clientIP",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "clientIP",
+                "requestId"
+              ],
+              "limit": 10,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [
+                {
+                  "dir": "DESC",
+                  "name": "request_count"
+                }
+              ],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "request_count",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "clientIP",
+                    "type": "Nullable(String)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "clientIP",
+                  "requestId"
+                ],
+                "limit": 10,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [
+                  {
+                    "dir": "DESC",
+                    "name": "request_count"
+                  }
+                ],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT clientIP, requestId, count(requestId) as request_count FROM ${table} GROUP BY clientIP, requestId ORDER BY request_count DESC LIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Requesting IP Addresses",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "decxq6bkoxekgf": {
+      "name": "Zuplo: Top 10 Locations",
+      "uid": "decxq6bkoxekgf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "fieldMinMax": true,
+            "mappings": [],
+            "noValue": "N/A",
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0.2,
+          "barWidth": 1,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "normal",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xField": "city",
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "builderOptions": "The query is not a select statement.",
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": "The query is not a select statement."
+            },
+            "pluginVersion": "4.0.6",
+            "rawSql": "SELECT\n    city,\n    count(*) AS request_count\nFROM (\n    SELECT\n        city,  -- Assuming you have a 'city' column in your table\n        *\n    FROM ${table}\n)\nWHERE $__timeFilter(timestamp)\nGROUP BY city\nORDER BY request_count DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Locations",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "aecy3csvo2yo0c": {
+      "name": "Zuplo: Top 10 Locations Response Time (Ms)",
+      "uid": "aecy3csvo2yo0c",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The top 10 requesting locations average reponse times",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "scheme",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "noValue": "[Unknown]",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 100
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 200
+                },
+                {
+                  "color": "#6ED0E0",
+                  "value": 300
+                },
+                {
+                  "color": "#EF843C",
+                  "value": 400
+                },
+                {
+                  "color": "#E24D42",
+                  "value": 500
+                },
+                {
+                  "color": "dark-red",
+                  "value": 600
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0,
+          "barWidth": 0.97,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    city,\n    avg(durationMs) AS average_duration_ms\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY city\nORDER BY count(*) DESC  -- Order by count without selecting it\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Locations Response Time (Ms)",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "eecy3dxm7gv0gb": {
+      "name": "Zuplo: Top 10 Users by Max RPS",
+      "uid": "eecy3dxm7gv0gb",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "Top 10 Users by Max RPS",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "noValue": "[unknown]",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0,
+          "barWidth": 0.97,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "normal",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    userSub,\n    max(requests_per_second) AS max_rps\nFROM (\n    SELECT\n        userSub,\n        toStartOfSecond(timestamp) AS time_bucket,  -- 1-second intervals\n        count(*) / (toUInt64(toStartOfSecond(timestamp)) - toUInt64(neighbor(toStartOfSecond(timestamp), -1, toDateTime64(0, 3)))) AS requests_per_second\n    FROM ${table}\n    WHERE $__timeFilter(timestamp)\n    GROUP BY userSub, time_bucket\n)\nGROUP BY userSub\nORDER BY max_rps DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Users by Max RPS",
+        "transparent": true,
+        "type": "barchart"
+      }
+    },
+    "decxywvz6jawwe": {
+      "name": "Zuplo: Top 10 Users by 429 Status Code",
+      "uid": "decxywvz6jawwe",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "The top 10 users that have had the most 429 responses for their requests during the selected time period",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "noValue": "[unknown]",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "barRadius": 0,
+          "barWidth": 0.97,
+          "fullHighlight": false,
+          "groupWidth": 0.7,
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "orientation": "horizontal",
+          "showValue": "auto",
+          "stacking": "none",
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          },
+          "xTickLabelRotation": 0,
+          "xTickLabelSpacing": 0
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    userSub,\n    COUNT(CASE WHEN statusCode = 429 THEN 1 END) AS rate_limited_requests\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY userSub\nORDER BY rate_limited_requests DESC\nLIMIT 10",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 10 Users by 429 Status Code",
+        "transparent": true,
+        "type": "barchart"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "4.0.6"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "The Grafana version of the analytics you find in the Zuplo Portal.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+      },
+      "description": "The total number of API requests over the selected time period",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "builderOptions": {
+            "aggregates": [
+              {
+                "aggregateType": "count",
+                "alias": "requests",
+                "column": "requestId"
+              }
+            ],
+            "columns": [
+              {
+                "custom": false,
+                "name": "requestId",
+                "type": "Nullable(String)"
+              },
+              {
+                "custom": false,
+                "name": "timestamp",
+                "type": "DateTime64(3)"
+              }
+            ],
+            "database": "sbxzuplotwist",
+            "filters": [],
+            "groupBy": [
+              "requestId",
+              "timestamp"
+            ],
+            "limit": 1000,
+            "meta": {},
+            "mode": "aggregate",
+            "orderBy": [
+              {
+                "dir": "ASC",
+                "name": "requestId"
+              }
+            ],
+            "queryType": "table",
+            "table": "zuplotest"
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                },
+                {
+                  "custom": false,
+                  "name": "timestamp",
+                  "type": "DateTime64(3)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "requestId",
+                "timestamp"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [
+                {
+                  "dir": "ASC",
+                  "name": "requestId"
+                }
+              ],
+              "queryType": "table",
+              "table": "zuplotest"
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time,  -- Or toStartOfHour, toStartOfDay, etc. for different time granularities\n    count(*) AS total_requests\nFROM ${table}\nWHERE $__timeFilter(timestamp)\nGROUP BY time\nORDER BY time ASC",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Requests",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 3,
+      "libraryPanel": {
+        "uid": "aecxq1x4kveo0a",
+        "name": "Zuplo: Requests by Status Code"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 5,
+      "libraryPanel": {
+        "uid": "becxpxy81f3eod",
+        "name": "Zuplo: Request Response Time"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Top 10",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 21
+      },
+      "id": 7,
+      "libraryPanel": {
+        "uid": "decy3bvqkkwzka",
+        "name": "Zuplo: Top 10 Users"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 7,
+        "y": 21
+      },
+      "id": 9,
+      "libraryPanel": {
+        "uid": "cecxpyk5wt7nkf",
+        "name": "Zuplo: Top 10 Routes by Request Count"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 21
+      },
+      "id": 11,
+      "libraryPanel": {
+        "uid": "cecxq0dtk8ao0c",
+        "name": "Zuplo: Top Requesting IP Addresses"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 13,
+      "libraryPanel": {
+        "uid": "decxq6bkoxekgf",
+        "name": "Zuplo: Top 10 Locations"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 14,
+      "libraryPanel": {
+        "uid": "aecy3csvo2yo0c",
+        "name": "Zuplo: Top 10 Locations Response Time (Ms)"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Rate Limiting",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 16,
+      "libraryPanel": {
+        "uid": "eecy3dxm7gv0gb",
+        "name": "Zuplo: Top 10 Users by Max RPS"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 17,
+      "libraryPanel": {
+        "uid": "decxywvz6jawwe",
+        "name": "Zuplo: Top 10 Users by 429 Status Code"
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Hydrolix - sbxzuplotwist",
+          "value": "de5x84pgij7r4a"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "selected_data_source",
+        "options": [],
+        "query": "grafana-clickhouse-datasource",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "description": "",
+        "hide": 2,
+        "label": "Table",
+        "name": "table",
+        "query": "${VAR_TABLE}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TABLE}",
+          "text": "${VAR_TABLE}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TABLE}",
+            "text": "${VAR_TABLE}",
+            "selected": false
+          }
+        ]
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Zuplo Standard Metrics - Grafana Version",
+  "uid": "becxrk017qgaof",
+  "version": 15,
+  "weekStart": ""
+}

--- a/zuplo/grafana-dashboards/zuplo-status-codes-error-rates.json
+++ b/zuplo/grafana-dashboards/zuplo-status-codes-error-rates.json
@@ -1,0 +1,753 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_HYDROLIX_- SBXZUPLOTWIST",
+      "label": "Hydrolix - sbxzuplotwist",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    },
+    {
+      "name": "VAR_TABLE",
+      "type": "constant",
+      "label": "Table",
+      "value": "sbxzuplotwist.zuplotest",
+      "description": ""
+    }
+  ],
+  "__elements": {
+    "aecxq2m1ju2o0e": {
+      "name": "Zuplo: Percentage of Requests Unauthorized (401) (Gauge)",
+      "uid": "aecxq2m1ju2o0e",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "What percentage of requests are being made by unauthorized clients",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 2,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "options": {
+          "minVizHeight": 75,
+          "minVizWidth": 75,
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "/^unauthorized_percentage$/",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "sizing": "auto"
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    (COUNT(CASE WHEN statusCode = 401 THEN 1 END) * 100) / COUNT(*) AS unauthorized_percentage\nFROM ${table}\nWHERE $__timeFilter(timestamp)",
+            "refId": "A"
+          }
+        ],
+        "title": "Percentage of Requests Unauthorized (401)",
+        "transparent": true,
+        "type": "gauge"
+      }
+    },
+    "decxq1bd5pukgf": {
+      "name": "Zuplo: Percentage of Requests Rate Limited (Gauge)",
+      "uid": "decxq1bd5pukgf",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "What percentage of requests are subject to a 429",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 2,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "options": {
+          "minVizHeight": 75,
+          "minVizWidth": 75,
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "/^rate_limited_percentage$/",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "sizing": "auto"
+        },
+        "pluginVersion": "10.4.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "columns": [],
+                "database": "",
+                "limit": 1000,
+                "mode": "list",
+                "queryType": "table",
+                "table": ""
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    (COUNT(CASE WHEN statusCode = 429 THEN 1 END) * 100) / COUNT(*) AS rate_limited_percentage\nFROM ${table}\nWHERE $__timeFilter(timestamp)",
+            "refId": "A"
+          }
+        ],
+        "title": "Percentage of Requests Rate Limited",
+        "transparent": true,
+        "type": "gauge"
+      }
+    },
+    "fecxq36cgp728d": {
+      "name": "Zuplo: Error Rates",
+      "uid": "fecxq36cgp728d",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "How many HTTP status errors between 40x and 50x are being seen",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Requests",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 400
+                },
+                {
+                  "color": "red",
+                  "value": 500
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [],
+              "columns": [
+                {
+                  "alias": "time",
+                  "hint": "time",
+                  "name": "timestamp",
+                  "type": "datetime"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "time"
+              ],
+              "meta": {},
+              "mode": "list",
+              "orderBy": [
+                {
+                  "dir": "ASC",
+                  "name": "time"
+                }
+              ],
+              "queryType": "timeseries",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [],
+                "columns": [
+                  {
+                    "alias": "time",
+                    "hint": "time",
+                    "name": "timestamp",
+                    "type": "datetime"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "time"
+                ],
+                "meta": {},
+                "mode": "list",
+                "orderBy": [
+                  {
+                    "dir": "ASC",
+                    "name": "time"
+                  }
+                ],
+                "queryType": "timeseries",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time,\n    CASE\n        WHEN statusCode = 400 THEN count(*)  -- Count 400 errors\n        ELSE 0                               -- Other status codes\n    END AS \"400\",  -- Alias for 400 errors\n    CASE\n        WHEN statusCode = 401 THEN count(*)  -- Count 401 errors\n        ELSE 0\n    END AS \"401\",  -- Alias for 401 errors\n    --... Add similar CASE statements for other status codes...\n    CASE\n        WHEN statusCode = 500 THEN count(*)  -- Count 500 errors\n        ELSE 0\n    END AS \"500\"   -- Alias for 500 errors\nFROM ${table}\nWHERE $__timeFilter(timestamp) AND statusCode BETWEEN 400 AND 599\nGROUP BY time, statusCode\nORDER BY time ASC",
+            "refId": "Error Rates"
+          }
+        ],
+        "title": "Error Rates",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    },
+    "aecxq1x4kveo0a": {
+      "name": "Zuplo: Requests by Status Code",
+      "uid": "aecxq1x4kveo0a",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+        },
+        "description": "How many requests are being processed of what HTTP status code",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 3,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "always",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "builderOptions": {
+              "aggregates": [
+                {
+                  "aggregateType": "count",
+                  "alias": "Code",
+                  "column": "statusCode"
+                },
+                {
+                  "aggregateType": "count",
+                  "alias": "requests",
+                  "column": "requestId"
+                }
+              ],
+              "columns": [
+                {
+                  "custom": false,
+                  "name": "statusCode",
+                  "type": "Nullable(Int32)"
+                },
+                {
+                  "custom": false,
+                  "name": "timestamp",
+                  "type": "DateTime64(3)"
+                },
+                {
+                  "custom": false,
+                  "name": "requestId",
+                  "type": "Nullable(String)"
+                }
+              ],
+              "database": "sbxzuplotwist",
+              "filters": [],
+              "groupBy": [
+                "timestamp",
+                "requestId",
+                "statusCode"
+              ],
+              "limit": 1000,
+              "meta": {},
+              "mode": "aggregate",
+              "orderBy": [],
+              "queryType": "table",
+              "table": "zuplotest"
+            },
+            "datasource": {
+              "type": "grafana-clickhouse-datasource",
+              "uid": "de5x84pgij7r4a"
+            },
+            "editorType": "sql",
+            "format": 1,
+            "meta": {
+              "builderOptions": {
+                "aggregates": [
+                  {
+                    "aggregateType": "count",
+                    "alias": "Code",
+                    "column": "statusCode"
+                  },
+                  {
+                    "aggregateType": "count",
+                    "alias": "requests",
+                    "column": "requestId"
+                  }
+                ],
+                "columns": [
+                  {
+                    "custom": false,
+                    "name": "statusCode",
+                    "type": "Nullable(Int32)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "timestamp",
+                    "type": "DateTime64(3)"
+                  },
+                  {
+                    "custom": false,
+                    "name": "requestId",
+                    "type": "Nullable(String)"
+                  }
+                ],
+                "database": "sbxzuplotwist",
+                "filters": [],
+                "groupBy": [
+                  "timestamp",
+                  "requestId",
+                  "statusCode"
+                ],
+                "limit": 1000,
+                "meta": {},
+                "mode": "aggregate",
+                "orderBy": [],
+                "queryType": "table",
+                "table": "zuplotest"
+              }
+            },
+            "pluginVersion": "4.0.6",
+            "queryType": "table",
+            "rawSql": "SELECT\n    toStartOfMinute(timestamp) AS time,\n    CASE WHEN statusCode = 200 THEN count(*) ELSE 0 END AS \"200\",  -- Success\n    CASE WHEN statusCode = 400 THEN count(*) ELSE 0 END AS \"400\",  -- Bad Request\n    CASE WHEN statusCode = 401 THEN count(*) ELSE 0 END AS \"401\",  -- Unauthorized\n    CASE WHEN statusCode = 403 THEN count(*) ELSE 0 END AS \"403\",  -- Forbidden\n    CASE WHEN statusCode = 404 THEN count(*) ELSE 0 END AS \"404\",  -- Not Found\n    CASE WHEN statusCode = 429 THEN count(*) ELSE 0 END AS \"429\",  -- Too Many Requests (Rate Limiting)\n    CASE WHEN statusCode = 500 THEN count(*) ELSE 0 END AS \"500\",  -- Internal Server Error\n    CASE WHEN statusCode = 502 THEN count(*) ELSE 0 END AS \"502\",  -- Bad Gateway\n    CASE WHEN statusCode = 503 THEN count(*) ELSE 0 END AS \"503\",  -- Service Unavailable\n    CASE WHEN statusCode = 504 THEN count(*) ELSE 0 END AS \"504\"   -- Gateway Timeout\nFROM ${table}\nWHERE $__timeFilter(timestamp)  -- Important for Grafana time range\nGROUP BY time, statusCode\nORDER BY time ASC",
+            "refId": "Requests by Status Code"
+          }
+        ],
+        "title": "Requests by Status Code",
+        "transparent": true,
+        "type": "timeseries"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "4.0.6"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+      },
+      "description": "What the current error rate is based on status codes",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${DS_HYDROLIX_- SBXZUPLOTWIST}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "meta": {
+            "builderOptions": {
+              "columns": [],
+              "database": "",
+              "limit": 1000,
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
+            }
+          },
+          "pluginVersion": "4.0.6",
+          "queryType": "table",
+          "rawSql": "SELECT\n    (COUNT(CASE WHEN NOT (statusCode >= 200 AND statusCode < 300) THEN 1 END) * 100) / COUNT(*) AS error_percentage\nFROM ${table}\nWHERE $__timeFilter(timestamp)",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Error Rate",
+      "transparent": true,
+      "type": "gauge"
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 7,
+        "y": 0
+      },
+      "id": 5,
+      "libraryPanel": {
+        "uid": "aecxq2m1ju2o0e",
+        "name": "Zuplo: Percentage of Requests Unauthorized (401) (Gauge)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 16,
+        "y": 0
+      },
+      "id": 7,
+      "libraryPanel": {
+        "uid": "decxq1bd5pukgf",
+        "name": "Zuplo: Percentage of Requests Rate Limited (Gauge)"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "libraryPanel": {
+        "uid": "fecxq36cgp728d",
+        "name": "Zuplo: Error Rates"
+      }
+    },
+    {
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 9,
+      "libraryPanel": {
+        "uid": "aecxq1x4kveo0a",
+        "name": "Zuplo: Requests by Status Code"
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Hydrolix - sbxzuplotwist",
+          "value": "de5x84pgij7r4a"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "selected_data_source",
+        "options": [],
+        "query": "grafana-clickhouse-datasource",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "description": "",
+        "hide": 2,
+        "label": "Table",
+        "name": "table",
+        "query": "${VAR_TABLE}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TABLE}",
+          "text": "${VAR_TABLE}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TABLE}",
+            "text": "${VAR_TABLE}",
+            "selected": false
+          }
+        ]
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Zuplo Status Codes & Error Rates",
+  "uid": "decy2669n83r4e",
+  "version": 7,
+  "weekStart": ""
+}

--- a/zuplo/openapi-schemas/hdx-config-api.yaml
+++ b/zuplo/openapi-schemas/hdx-config-api.yaml
@@ -1,0 +1,14132 @@
+openapi: 3.0.3
+info:
+  title: Config API
+  version: '1'
+  description: "\n        API for configuration of Hydrolix entities, like users,\
+    \ projects, tables, views, and transforms.\n\n        - Contact URL: https://www.hydrolix.io.\n\
+    \n        -  Terms Of Service: https://docs.hydrolix.io/legal/terms-of-service.\n\
+    \n    "
+paths:
+  /config/v1/activity/:
+    get:
+      operationId: config_v1_activity_list
+      description: |-
+        Return a list of audit activities
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get audit activities
+      parameters:
+      - in: query
+        name: action
+        schema:
+          type: string
+        description: The action type to filter by
+      - in: query
+        name: max_date
+        schema:
+          type: string
+        description: The maximum date to return
+      - in: query
+        name: min_date
+        schema:
+          type: string
+        description: The minimum date to return
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - Audit
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedActivityList'
+          description: ''
+  /config/v1/activity/{id}/:
+    get:
+      operationId: config_v1_activity_retrieve
+      description: |-
+        Return an audit activity belonging to the specified id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get audit activity
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this audit.
+        required: true
+      tags:
+      - Audit
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Activity'
+          description: ''
+  /config/v1/auth/identity_providers/:
+    get:
+      operationId: config_v1_auth_identity_providers_list
+      description: Return a list of currently configured identity providers that will
+        display on the SSO login page.
+      summary: List Identity Providers
+      tags:
+      - Auth
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IdentityProvider'
+          description: ''
+  /config/v1/auth_logs/:
+    get:
+      operationId: config_v1_auth_logs_retrieve
+      description: |-
+        Retrieve list of auth logs based on request body filters
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get auth logs
+      parameters:
+      - in: query
+        name: event_types
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - AUTHREQID_TO_TOKEN
+            - AUTHREQID_TO_TOKEN_ERROR
+            - CLIENT_DELETE
+            - CLIENT_DELETE_ERROR
+            - CLIENT_INFO
+            - CLIENT_INFO_ERROR
+            - CLIENT_INITIATED_ACCOUNT_LINKING
+            - CLIENT_INITIATED_ACCOUNT_LINKING_ERROR
+            - CLIENT_LOGIN
+            - CLIENT_LOGIN_ERROR
+            - CLIENT_REGISTER
+            - CLIENT_REGISTER_ERROR
+            - CLIENT_UPDATE
+            - CLIENT_UPDATE_ERROR
+            - CODE_TO_TOKEN
+            - CODE_TO_TOKEN_ERROR
+            - CUSTOM_REQUIRED_ACTION
+            - CUSTOM_REQUIRED_ACTION_ERROR
+            - DELETE_ACCOUNT
+            - DELETE_ACCOUNT_ERROR
+            - EXECUTE_ACTIONS
+            - EXECUTE_ACTIONS_ERROR
+            - EXECUTE_ACTION_TOKEN
+            - EXECUTE_ACTION_TOKEN_ERROR
+            - FEDERATED_IDENTITY_LINK
+            - FEDERATED_IDENTITY_LINK_ERROR
+            - GRANT_CONSENT
+            - GRANT_CONSENT_ERROR
+            - IDENTITY_PROVIDER_FIRST_LOGIN
+            - IDENTITY_PROVIDER_FIRST_LOGIN_ERROR
+            - IDENTITY_PROVIDER_LINK_ACCOUNT
+            - IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR
+            - IDENTITY_PROVIDER_LOGIN
+            - IDENTITY_PROVIDER_LOGIN_ERROR
+            - IDENTITY_PROVIDER_POST_LOGIN
+            - IDENTITY_PROVIDER_POST_LOGIN_ERROR
+            - IDENTITY_PROVIDER_RESPONSE
+            - IDENTITY_PROVIDER_RESPONSE_ERROR
+            - IDENTITY_PROVIDER_RETRIEVE_TOKEN
+            - IDENTITY_PROVIDER_RETRIEVE_TOKEN_ERROR
+            - IMPERSONATE
+            - IMPERSONATE_ERROR
+            - INTROSPECT_TOKEN
+            - INTROSPECT_TOKEN_ERROR
+            - INVALID_SIGNATURE
+            - INVALID_SIGNATURE_ERROR
+            - LOGIN
+            - LOGIN_ERROR
+            - LOGOUT
+            - LOGOUT_ERROR
+            - OAUTH2_DEVICE_AUTH
+            - OAUTH2_DEVICE_AUTH_ERROR
+            - OAUTH2_DEVICE_CODE_TO_TOKEN
+            - OAUTH2_DEVICE_CODE_TO_TOKEN_ERROR
+            - OAUTH2_DEVICE_VERIFY_USER_CODE
+            - OAUTH2_DEVICE_VERIFY_USER_CODE_ERROR
+            - PERMISSION_TOKEN
+            - PERMISSION_TOKEN_ERROR
+            - PUSHED_AUTHORIZATION_REQUEST
+            - PUSHED_AUTHORIZATION_REQUEST_ERROR
+            - REFRESH_TOKEN
+            - REFRESH_TOKEN_ERROR
+            - REGISTER
+            - REGISTER_ERROR
+            - REGISTER_NODE
+            - REGISTER_NODE_ERROR
+            - REMOVE_FEDERATED_IDENTITY
+            - REMOVE_FEDERATED_IDENTITY_ERROR
+            - REMOVE_TOTP
+            - REMOVE_TOTP_ERROR
+            - RESET_PASSWORD
+            - RESET_PASSWORD_ERROR
+            - RESTART_AUTHENTICATION
+            - RESTART_AUTHENTICATION_ERROR
+            - REVOKE_GRANT
+            - REVOKE_GRANT_ERROR
+            - SEND_IDENTITY_PROVIDER_LINK
+            - SEND_IDENTITY_PROVIDER_LINK_ERROR
+            - SEND_RESET_PASSWORD
+            - SEND_RESET_PASSWORD_ERROR
+            - SEND_VERIFY_EMAIL
+            - SEND_VERIFY_EMAIL_ERROR
+            - TOKEN_EXCHANGE
+            - TOKEN_EXCHANGE_ERROR
+            - UNREGISTER_NODE
+            - UNREGISTER_NODE_ERROR
+            - UPDATE_CONSENT
+            - UPDATE_CONSENT_ERROR
+            - UPDATE_EMAIL
+            - UPDATE_EMAIL_ERROR
+            - UPDATE_PASSWORD
+            - UPDATE_PASSWORD_ERROR
+            - UPDATE_PROFILE
+            - UPDATE_PROFILE_ERROR
+            - UPDATE_TOTP
+            - UPDATE_TOTP_ERROR
+            - USER_INFO_REQUEST
+            - USER_INFO_REQUEST_ERROR
+            - VALIDATE_ACCESS_TOKEN
+            - VALIDATE_ACCESS_TOKEN_ERROR
+            - VERIFY_EMAIL
+            - VERIFY_EMAIL_ERROR
+            - VERIFY_PROFILE
+            - VERIFY_PROFILE_ERROR
+        description: Event types filter
+      - in: query
+        name: from_date
+        schema:
+          type: string
+        description: From date in in YYYY-MM-DD format
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          default: 100
+        description: Limit in number of events
+      - in: query
+        name: to_date
+        schema:
+          type: string
+        description: To date in in YYYY-MM-DD format
+      - in: query
+        name: user_id
+        schema:
+          type: string
+          format: uuid
+        description: User ID filter
+      tags:
+      - Auth
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthLog'
+          description: ''
+  /config/v1/change_password/:
+    put:
+      operationId: config_v1_change_password_update
+      description: |-
+        Use this endpoint to change your login password
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Change password
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePassword'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangePassword'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/cluster_logs/:
+    get:
+      operationId: config_v1_cluster_logs_retrieve
+      description: |-
+        Returns a zipped file with cluster, json config file and pods' logs information
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get cluster logs
+      parameters:
+      - in: query
+        name: pod_name
+        schema:
+          type: string
+        description: kubernetes container name
+      - in: query
+        name: results
+        schema:
+          type: string
+        description: Indicate the amount of pods' logs to return in the response
+      - in: query
+        name: show_logs
+        schema:
+          type: string
+        description: if True, returns pods' logs in the response
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/dictionary_input_formats/:
+    get:
+      operationId: config_v1_dictionary_input_formats_retrieve
+      description: |-
+        Return a list of valid dictionary input format choise
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Get dictionary input format choises
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                InputFormats:
+                  value:
+                  - TabSeparated
+                  - TabSeparatedRaw
+                  - TabSeparatedWithNames
+                  - TabSeparatedWithNamesAndTypes
+                  - TabSeparatedRawWithNames
+                  - TabSeparatedRawWithNamesAndTypes
+                  - CSV
+                  - CSVWithNames
+                  - CSVWithNamesAndTypes
+                  - Values
+                  - JSON
+                  - JSONColumns
+                  - JSONColumnsWithMetadata
+                  - JSONCompact
+                  - JSONEachRow
+                  - JSONObjectEachRow
+                  - TSKV
+                  - LineAsString
+                  - CustomSeparated
+                  - CustomSeparatedWithNames
+                  - CustomSeparatedWithNamesAndTypes
+                  - BSONEachRow
+                  - Native
+                  - RawBLOB
+                  - Regexp
+                  summary: input formats
+          description: ''
+  /config/v1/dictionary_layouts/:
+    get:
+      operationId: config_v1_dictionary_layouts_retrieve
+      description: |-
+        Return a list of valid dictionary layout choises
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Get dictionary layouts
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                Layouts:
+                  value:
+                  - flat
+                  - hashed
+                  - sparse_hashed
+                  - complex_key_hashed
+                  - complex_key_sparse_hashed
+                  - hashed_array
+                  - complex_key_hashed_array
+                  - range_hashed
+                  - complex_key_range_hashed
+                  - cache
+                  - complex_key_cache
+                  - ssd_cache
+                  - complex_key_ssd_cache
+                  - direct
+                  - complex_key_direct
+                  - ip_trie
+                  - regexp_tree
+                  summary: layouts
+          description: ''
+  /config/v1/invites/:
+    get:
+      operationId: config_v1_invites_list
+      description: |-
+        Lists all invites that have been sent out, both pending and claimed. Setting query parameter `pending_only` to True or 1 only returns pending invites.
+
+        **Permissions required**:
+
+        IsAuthenticated
+      summary: Get invites
+      parameters:
+      - in: query
+        name: pending_only
+        schema:
+          type: boolean
+          default: false
+        description: If set to true, only return pending invites
+      tags:
+      - Invites
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Invite'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_invites_create
+      description: |-
+        Create an invite for a user via a valid emailn
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create an invite
+      tags:
+      - Invites
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Invite'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - Either the resource was not found or the user
+            already exists
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          description: Success - Invite was sent.
+  /config/v1/invites/{id}/:
+    get:
+      operationId: config_v1_invites_retrieve
+      description: |-
+        Return a single invite instance using an invite ID
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get an invite
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Invites
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - Either the resource was not found or the user
+            already exists
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          description: Success - Invite was sent.
+    delete:
+      operationId: config_v1_invites_destroy
+      description: |-
+        Delete a pending invite
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete an invite
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Invites
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/invites/{id}/resend_invite/:
+    post:
+      operationId: config_v1_invites_resend_invite_create
+      description: |-
+        Resends an invite link via Invite ID
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Resend invite
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this invite.
+        required: true
+      tags:
+      - Invites
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - Either the resource was not found or the user
+            already exists
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          description: Success - Invite was sent.
+  /config/v1/invites/bulk_invite/:
+    post:
+      operationId: config_v1_invites_bulk_invite_create
+      description: |-
+        Create invites for multiple users
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Bulk invite
+      tags:
+      - Invites
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Invite'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - Either the resource was not found or the user
+            already exists
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          description: Success - Invite was sent.
+  /config/v1/invites/claim_invite/:
+    post:
+      operationId: config_v1_invites_claim_invite_create
+      description: |-
+        Claim an invite
+
+        **Permissions required**:
+        AllowAny
+      summary: Claim invite
+      tags:
+      - Invites
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Invite'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - Check to make sure the passwords match and the
+            token and uuidb64 are correct
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          description: Success - Invite was accepted.
+  /config/v1/invites/invite_url/:
+    post:
+      operationId: config_v1_invites_invite_url_create
+      description: |-
+        Generate a user and immediately return the Invite URL instead of emailing it
+
+        **Permissions required**:
+        AllowAny
+      summary: Create invite url
+      parameters:
+      - in: query
+        name: email
+        schema:
+          type: string
+          format: email
+          minLength: 1
+        required: true
+      - in: query
+        name: org
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: query
+        name: roles
+        schema:
+          type: array
+          items:
+            type: string
+        required: true
+      tags:
+      - Invites
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Invite'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - Either the resource was not found or the user
+            already exists
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InviteURLResponse'
+          description: Success
+  /config/v1/job_statuses/:
+    get:
+      operationId: config_v1_job_statuses_retrieve
+      description: |-
+        Return a list of the allowed job statuses
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Job statuses
+      tags:
+      - Alter Jobs
+      - Batch Jobs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                JobStatus:
+                  value:
+                  - ready
+                  - running
+                  - failed
+                  - pending
+                  - done
+                  - canceled
+                  - unknown
+                  summary: job status
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/login/:
+    get:
+      operationId: config_v1_login_retrieve
+      description: |-
+        Login to Hydrolix using the SSO login flow, required if using an external IDP.
+        Optionally, an IDP ID can be provided to redirect directly to the login page of that IDP.
+      summary: Login to Hydrolix using SSO
+      parameters:
+      - in: query
+        name: idp_hint
+        schema:
+          type: string
+        description: ID of the IDP that should be used to sign in
+      - in: query
+        name: redirect_uri
+        schema:
+          type: string
+        description: The URI to redirect to after successful login
+      tags:
+      - Auth
+      security:
+      - {}
+      responses:
+        '302':
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL of the SSO sign on page
+          description: No response body
+    post:
+      operationId: config_v1_login_create
+      description: |-
+        Use this endpoint to log into Hydrolix and receive a JWT token for use with
+                   further calls. The username and password are passed in the body of the
+                   json request document. The document returned includes the organizations
+                   that the user belongs to as well as the access token
+
+        **Permissions required**:
+        AllowAny
+      summary: Login to Hydrolix
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Login'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Login'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Login'
+        required: true
+      responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    title: The UUID for the user
+                    type: string
+                    format: uuid
+                    readOnly: true
+                  email:
+                    title: The user email
+                    type: string
+                    readOnly: true
+                  orgs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        uuid:
+                          type: string
+                          title: The UUID of the organization
+                          format: uuid
+                          readOnly: true
+                        name:
+                          type: string
+                          title: The name of the organization
+                          readOnly: true
+                        type:
+                          type: string
+                          title: The type of organization.
+                          readOnly: true
+                    readOnly: true
+                  roles:
+                    type: array
+                    title: Roles
+                    items:
+                      type: string
+                      title: The role the user belongs to
+                      readOnly: true
+                    readOnly: true
+                  auth_token:
+                    type: object
+                    readOnly: true
+                    properties:
+                      access_token:
+                        title: the access token to be used in the Authorization header
+                          for API calls that require authentication
+                        type: string
+                        readOnly: true
+                      expires_in:
+                        title: the number of seconds the access_token is valid for
+                        type: number
+                        readOnly: true
+                      token_type:
+                        title: Bearer is currently supported
+                        type: string
+                        readOnly: true
+          description: Success
+  /config/v1/orgs/:
+    get:
+      operationId: config_v1_orgs_list
+      description: |-
+        Return a list of orgs
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get orgs
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedOrgList'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/catalog/:
+    get:
+      operationId: config_v1_orgs_catalog_list
+      description: |-
+        Get catalog
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get catalog
+      parameters:
+      - in: query
+        name: max_timestamp_after
+        schema:
+          type: string
+          format: date-time
+        description: The latest timestamp of the contiguous time-series data held
+          by this partition.
+      - in: query
+        name: max_timestamp_before
+        schema:
+          type: string
+          format: date-time
+        description: The latest timestamp of the contiguous time-series data held
+          by this partition.
+      - in: query
+        name: min_timestamp_after
+        schema:
+          type: string
+          format: date-time
+        description: The earliest timestamp of the contiguous time-series data held
+          by this partition.
+      - in: query
+        name: min_timestamp_before
+        schema:
+          type: string
+          format: date-time
+        description: The earliest timestamp of the contiguous time-series data held
+          by this partition.
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: project
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+      - in: query
+        name: root_path
+        schema:
+          type: string
+        description: Root path
+      - in: query
+        name: shard_key
+        schema:
+          type: string
+        description: Shard key
+      - in: query
+        name: table
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCatalogList'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/catalog/download/:
+    get:
+      operationId: config_v1_orgs_catalog_download_retrieve
+      description: |-
+        Download catalog for the specified org id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Download catalog
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          description: Success
+  /config/v1/orgs/{org_id}/catalog/upload/:
+    post:
+      operationId: config_v1_orgs_catalog_upload_create
+      description: |-
+        Upload catalog for the specified org id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Upload catalog
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Orgs
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Catalog'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '201':
+          description: Success
+  /config/v1/orgs/{org_id}/credentials/:
+    get:
+      operationId: config_v1_orgs_credentials_list
+      description: |-
+        List the credentials in an organization. Returns an array of credentials
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get credentials
+      parameters:
+      - in: query
+        name: cloud
+        schema:
+          type: string
+        description: Filter credentials by cloud
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: query
+        name: type
+        schema:
+          type: string
+        description: Filter credentials by type
+      tags:
+      - Credentials
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Credential'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_credentials_create
+      description: |-
+        Create a credential in an organization.
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create credential
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Credential'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Credential'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Credential already exists or the name field is not provided
+            in the request document.
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/credentials/{id}/:
+    get:
+      operationId: config_v1_orgs_credentials_retrieve
+      description: |-
+        Returns the credential
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get a credential
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Credentials
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Credential'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_credentials_destroy
+      description: |-
+        Delete credential specified by id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete credential
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Credentials
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/credentials/types/:
+    get:
+      operationId: config_v1_orgs_credentials_types_retrieve
+      description: |-
+        Return the keys and value for the different credential types
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get credential types
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Credentials
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                CredentialTypes:
+                  value:
+                    aws_iam_role:
+                      cloud: aws
+                      fields:
+                        role_arn:
+                          required: true
+                        access_key_id:
+                          required: false
+                        secret_access_key:
+                          required: false
+                    aws_temporary_security_credentials_sts:
+                      cloud: aws
+                      fields:
+                        access_key_id:
+                          required: true
+                        secret_access_key:
+                          required: true
+                        session_token:
+                          required: true
+                    aws_access_keys:
+                      cloud: aws
+                      fields:
+                        access_key_id:
+                          required: true
+                        secret_access_key:
+                          required: true
+                    aws_presigned_urls:
+                      cloud: aws
+                      fields:
+                        url:
+                          required: true
+                    gcp_oauth_tokens:
+                      cloud: gcp
+                      fields:
+                        access_token:
+                          required: true
+                    gcp_service_account_keys:
+                      cloud: gcp
+                      fields:
+                        type:
+                          required: true
+                        project_id:
+                          required: true
+                        private_key_id:
+                          required: true
+                        private_key:
+                          required: true
+                        client_email:
+                          required: true
+                        client_id:
+                          required: true
+                        auth_uri:
+                          required: true
+                        token_uri:
+                          required: true
+                        auth_provider_x509_cert_url:
+                          required: true
+                        client_x509_cert_url:
+                          required: true
+                    gcp_signed_urls:
+                      cloud: gcp
+                      fields:
+                        url:
+                          required: true
+                    gcp_hmac_keys:
+                      cloud: gcp
+                      fields:
+                        access_key_id:
+                          required: true
+                        secret_access_key:
+                          required: true
+                    azure_ad_credentials:
+                      cloud: azure
+                      fields:
+                        token:
+                          required: true
+                    azure_shared_key_credentials:
+                      cloud: azure
+                      fields:
+                        account_name:
+                          required: true
+                        account_key:
+                          required: true
+                    azure_shared_access_signature:
+                      cloud: azure
+                      fields:
+                        sas_token:
+                          required: true
+                    azure_connection_string:
+                      cloud: azure
+                      fields:
+                        connection_string:
+                          required: true
+                    linode_api_token:
+                      cloud: linode
+                      fields:
+                        token:
+                          required: true
+                    linode_access_keys:
+                      cloud: linode
+                      fields:
+                        access_key_id:
+                          required: true
+                        secret_access_key:
+                          required: true
+                    akamai_siem:
+                      cloud: null
+                      fields:
+                        host:
+                          required: true
+                        entity_id:
+                          required: true
+                        client_secret:
+                          required: true
+                        client_token:
+                          required: true
+                        access_token:
+                          required: true
+                  summary: credential types
+          description: Success
+  /config/v1/orgs/{org_id}/jobs/alter/:
+    get:
+      operationId: config_v1_orgs_jobs_alter_list
+      description: |-
+        Return all alter jobs belonging to specified org id
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Get alter jobs
+      parameters:
+      - in: query
+        name: date_max
+        schema:
+          type: string
+        description: Filter based on maximum job creation datetime
+      - in: query
+        name: date_min
+        schema:
+          type: string
+        description: Filter based on minimum job creation datetime
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter based on exact job name
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: status
+        schema:
+          type: string
+        description: Filter based on exact job status
+      - in: query
+        name: table_id
+        schema:
+          type: string
+        description: Filter based on exact job table id
+      - in: query
+        name: table_name
+        schema:
+          type: string
+        description: Filter based on exact job table name
+      tags:
+      - Alter Jobs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAlterJobList'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/jobs/alter/{id}/:
+    get:
+      operationId: config_v1_orgs_jobs_alter_retrieve
+      description: |-
+        Return an alter job instance belonging to specified org id
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Get alter job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Alter Jobs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlterJob'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_jobs_alter_destroy
+      description: |-
+        Delete an alter job
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Delete alter job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Alter Jobs
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/jobs/alter/{id}/cancel/:
+    post:
+      operationId: config_v1_orgs_jobs_alter_cancel_create
+      description: |-
+        Cancel an alter job
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Cancel an alter job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Alter Jobs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlterJob'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlterJob'
+          description: ''
+  /config/v1/orgs/{org_id}/jobs/alter/{id}/commit/:
+    post:
+      operationId: config_v1_orgs_jobs_alter_commit_create
+      description: |-
+        Commit an specific job
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Commit job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Alter Jobs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlterJob'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlterJob'
+          description: ''
+  /config/v1/orgs/{org_id}/jobs/alter/{id}/retry/:
+    post:
+      operationId: config_v1_orgs_jobs_alter_retry_create
+      description: |-
+        Retry an specific alter job
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Retry an alter job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Alter Jobs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlterJob'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlterJob'
+          description: ''
+  /config/v1/orgs/{org_id}/jobs/alter/{id}/status/:
+    get:
+      operationId: config_v1_orgs_jobs_alter_status_retrieve
+      description: |-
+        Return the current status of the alter job
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Get alter job status
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Alter Jobs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                JobStatus:
+                  value:
+                    id: string
+                    status: canceled
+                  summary: job status
+          description: Success
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/jobs/alter/{id}/verify/:
+    get:
+      operationId: config_v1_orgs_jobs_alter_verify_retrieve
+      description: |-
+        Verify indicated alter job
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Verify alter job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Alter Jobs
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlterJob'
+          description: ''
+  /config/v1/orgs/{org_id}/jobs/batch/:
+    get:
+      operationId: config_v1_orgs_jobs_batch_list
+      description: |-
+        Return all jobs belonging to specified org id
+
+        **Permissions required**:
+        IsAuthenticated, JobPermissions
+      summary: Get batch jobs
+      parameters:
+      - in: query
+        name: date_max
+        schema:
+          type: string
+        description: Filter based on maximum job creation datetime
+      - in: query
+        name: date_min
+        schema:
+          type: string
+        description: Filter based on minimum job creation datetime
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter based on exact job name
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: status
+        schema:
+          type: string
+        description: Filter based on exact job status
+      - in: query
+        name: table_id
+        schema:
+          type: string
+        description: Filter based on exact job table id
+      - in: query
+        name: table_name
+        schema:
+          type: string
+        description: Filter based on exact job table name
+      tags:
+      - Batch Jobs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBatchJobList'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_jobs_batch_create
+      description: |-
+        Create a job in specified org id
+
+        **Permissions required**:
+        IsAuthenticated, JobPermissions
+      summary: Create batch job
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Batch Jobs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchJob'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchJob'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/jobs/batch/{id}/:
+    get:
+      operationId: config_v1_orgs_jobs_batch_retrieve
+      description: |-
+        Return a job instance belonging to specified org id
+
+        **Permissions required**:
+        IsAuthenticated, JobPermissions
+      summary: Get batch job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Batch Jobs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchJob'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_jobs_batch_destroy
+      description: |-
+        Delete a job instance belonging to specified org id
+
+        **Permissions required**:
+        IsAuthenticated, JobPermissions
+      summary: Delete a batch job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Batch Jobs
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/jobs/batch/{id}/cancel/:
+    post:
+      operationId: config_v1_orgs_jobs_batch_cancel_create
+      description: |-
+        Cancel a batch job for the specified id
+
+        **Permissions required**:
+        IsAuthenticated, JobPermissions
+      summary: Cancel a batch job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Batch Jobs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchJob'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchJob'
+          description: ''
+  /config/v1/orgs/{org_id}/jobs/batch/{id}/retry/:
+    post:
+      operationId: config_v1_orgs_jobs_batch_retry_create
+      description: |-
+        Retry a batch job for the specified id
+
+        **Permissions required**:
+        IsAuthenticated, JobPermissions
+      summary: Retry a batch job
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Batch Jobs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchJob'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchJob'
+          description: ''
+  /config/v1/orgs/{org_id}/jobs/batch/{id}/status/:
+    get:
+      operationId: config_v1_orgs_jobs_batch_status_retrieve
+      description: |-
+        Get the status for the batch job id specified
+
+        **Permissions required**:
+        IsAuthenticated, JobPermissions
+      summary: Get batch job status
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Batch Jobs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                JobStatus:
+                  value:
+                    id: string
+                    status: canceled
+                  summary: job status
+          description: Success
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/merge_pools/:
+    get:
+      operationId: config_v1_orgs_merge_pools_retrieve
+      description: |-
+        Return the value of the merge pool setting
+
+        **Permissions required**:
+        AllowAny, MergePoolPermissions
+      summary: Get merge pools
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                MergePools:
+                  value:
+                    small: merge-peer
+                    medium: merge-peer-ii
+                    large: merge-peer-iii
+                  summary: merge pools
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_merge_pools_update
+      description: |-
+        Update merge pools setting values
+
+        **Permissions required**:
+        AllowAny, MergePoolPermissions
+      summary: Update merge pools
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Orgs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Org'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                MergePools:
+                  value:
+                    small: merge-peer
+                    medium: merge-peer-ii
+                    large: merge-peer-iii
+                  summary: merge pools
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/:
+    get:
+      operationId: config_v1_orgs_projects_list
+      description: |-
+        List the projects in an organization. Returns an array of projects
+
+        **Permissions required**:
+        IsAuthenticated, ProjectPermissions
+      summary: Get projects
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Projects
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_create
+      description: |-
+        Create a project in an organization.
+
+        **Permissions required**:
+        IsAuthenticated, ProjectPermissions
+      summary: Create project
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Projects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Project'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Project already exists or the name field is not provided in
+            the request document.
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_retrieve
+      description: |-
+        Returns the project
+
+        **Permissions required**:
+        IsAuthenticated, ProjectPermissions
+      summary: Get project
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Projects
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_update
+      description: |-
+        Updates the project
+
+        **Permissions required**:
+        IsAuthenticated, ProjectPermissions
+      summary: Update project
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Projects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Project'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Project already exists or the name field is not provided in
+            the request document.
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_projects_partial_update
+      description: |-
+        Updates the project
+
+        **Permissions required**:
+        IsAuthenticated, ProjectPermissions
+      summary: Path project
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Projects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedProject'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Project already exists or the name field is not provided in
+            the request document.
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_destroy
+      description: |-
+        Deletes the project
+
+        **Permissions required**:
+        IsAuthenticated, ProjectPermissions
+      summary: Delete project
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Projects
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{id}/activity/:
+    get:
+      operationId: config_v1_orgs_projects_activity_retrieve
+      description: |-
+        Returns the activity for the specified project id
+
+        **Permissions required**:
+        IsAuthenticated, ProjectPermissions
+      summary: Get project activity
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Projects
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Activity'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/dictionaries/:
+    get:
+      operationId: config_v1_orgs_projects_dictionaries_list
+      description: |-
+        List the dictionaries in a project. Returns an array of dictionaries
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Get dictionaries
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Dictionary'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_dictionaries_create
+      description: |-
+        Create a dictionary in a project
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Create a dictionary
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dictionary'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dictionary'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/dictionaries/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_dictionaries_retrieve
+      description: |-
+        Return a dictionary instance belonging to a project
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Get a dictionary
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dictionary'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_dictionaries_update
+      description: |-
+        Update a dictionary instance belonging to a project
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Update a dictionary
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dictionary'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dictionary'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_projects_dictionaries_partial_update
+      description: |-
+        Patch a dictionary instance belonging to a project
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Patch a dictionary
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedDictionary'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dictionary'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_dictionaries_destroy
+      description: |-
+        Delete dictionary
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Delete a dictionary
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/dictionaries/{id}/activity/:
+    get:
+      operationId: config_v1_orgs_projects_dictionaries_activity_retrieve
+      description: |-
+        Return a dictionary's activity
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Get dictionary activity
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dictionary'
+          description: ''
+  /config/v1/orgs/{org_id}/projects/{project_id}/dictionaries/files/:
+    get:
+      operationId: config_v1_orgs_projects_dictionaries_files_list
+      description: |-
+        List the dictionaries files in a project. Returns an array of dictionary file names
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Get dictionary files
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          description: Operation success
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_dictionaries_files_create
+      description: |-
+        Upload the dictionary file
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Upload the dictionary file
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DictionaryFile'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DictionaryFile'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DictionaryFile'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          description: Operation success
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/dictionaries/files/{filename}/:
+    get:
+      operationId: config_v1_orgs_projects_dictionaries_files_retrieve
+      description: |-
+        Checks if filename exists in the bucket
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Get a dictionary file
+      parameters:
+      - in: path
+        name: filename
+        schema:
+          type: string
+        description: dictionary's file name
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          description: Operation success
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_dictionaries_files_update
+      description: |-
+        Update an existing file with a new one. Does not allow renaming.
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Update a dictionary file
+      parameters:
+      - in: path
+        name: filename
+        schema:
+          type: string
+        description: dictionary's file name
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DictionaryFile'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DictionaryFile'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DictionaryFile'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          description: Operation success
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_dictionaries_files_destroy
+      description: |-
+        Delete dictionary file
+
+        **Permissions required**:
+        ('list_dictionary', 'Can list dictionaries')
+      summary: Delete dictionary file
+      parameters:
+      - in: path
+        name: filename
+        schema:
+          type: string
+        description: dictionary's file name
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Dictionaries
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/functions/:
+    get:
+      operationId: config_v1_orgs_projects_functions_list
+      description: |-
+        List the functions in a project. Returns an array of functions
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get functions
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Functions
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Function'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_functions_create
+      description: |-
+        Create a function in a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create function
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Functions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Function'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Function'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/functions/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_functions_retrieve
+      description: |-
+        Return a function instance belonging to a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get function
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Functions
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Function'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_functions_update
+      description: |-
+        Update a function instance belonging to a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update function
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Functions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Function'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Function'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_projects_functions_partial_update
+      description: |-
+        Patch a function instance belonging to a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch function
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Functions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedFunction'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Function'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_functions_destroy
+      description: |-
+        Deletes the function
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete function
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Functions
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/functions/bulk_function/:
+    post:
+      operationId: config_v1_orgs_projects_functions_bulk_function_create
+      description: |-
+        Create multiple functions
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create functions
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Functions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Function'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Function'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/generateschema/:
+    post:
+      operationId: config_v1_orgs_projects_generateschema_create
+      description: |-
+        Generate dictionary schema for the specified project id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Generate project schema
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Transforms
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DictionaryGenerate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DictionaryGenerate'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DictionaryGenerate'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryGenerate'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/query_options/:
+    get:
+      operationId: config_v1_orgs_projects_query_options_retrieve
+      description: |-
+        Returns the query options setting for the specified project id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get project query options
+      externalDocs:
+        url: https://docs.hydrolix.io/docs/query-circuit-breakers
+        description: Query circuit breakers
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Query Options
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_query_options_update
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Query Options
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectQueryOptions'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectQueryOptions'
+          description: ''
+    patch:
+      operationId: config_v1_orgs_projects_query_options_partial_update
+      description: |-
+        Patch the query options setting for the specified project id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch project query options
+      externalDocs:
+        url: https://docs.hydrolix.io/docs/query-circuit-breakers
+        description: Query circuit breakers
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Query Options
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectQueryOptions'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/stats/:
+    get:
+      operationId: config_v1_orgs_projects_stats_retrieve
+      description: |-
+        Returns stats information for the specified project id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get project stats
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Projects
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectStats'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/:
+    get:
+      operationId: config_v1_orgs_projects_tables_list
+      description: |-
+        List the tables in a project. Returns an array of tables
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: List tables
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Tables
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Table'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_tables_create
+      description: |-
+        Create a table in a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create table
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Tables
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Table'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Table'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_tables_retrieve
+      description: |-
+        Return a table instance belonging to a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get table
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Tables
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Table'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_tables_update
+      description: |-
+        Update a table instance belonging to a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update table
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Tables
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Table'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Table'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_projects_tables_partial_update
+      description: |-
+        Patch a table instance belonging to a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch table
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Tables
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTable'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Table'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_tables_destroy
+      description: |-
+        Delete a table instance belonging to a project
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete table
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Tables
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{id}/activity/:
+    get:
+      operationId: config_v1_orgs_projects_tables_activity_retrieve
+      description: |-
+        Return the activity for the specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get table activity
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Tables
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Activity'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{id}/catalog_urls/:
+    get:
+      operationId: config_v1_orgs_projects_tables_catalog_urls_retrieve
+      summary: Get presigned URLs for partitions in the catalog
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: query
+        name: max_timestamp
+        schema:
+          type: string
+        description: The maximum timestamp for the partitions that will be returned
+        required: true
+      - in: query
+        name: min_timestamp
+        schema:
+          type: string
+        description: The minimum timestamp for the partitions that will be returned
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      tags:
+      - Tables
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Table'
+          description: ''
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/columns/:
+    get:
+      operationId: config_v1_orgs_projects_tables_columns_list
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - config
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Column'
+          description: ''
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/columns/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_tables_columns_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this column.
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - config
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Column'
+          description: ''
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/columns/{id}/add_name/:
+    post:
+      operationId: config_v1_orgs_projects_tables_columns_add_name_create
+      description: Add a new name to the column
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this column.
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - config
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Column'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Column'
+          description: ''
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/generateschema/:
+    post:
+      operationId: config_v1_orgs_projects_tables_generateschema_create
+      description: |-
+        Generate transform schema for the specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Generate table schema
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Transforms
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TransformGenerate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TransformGenerate'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransformGenerate'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransformGenerate'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/partitions/:
+    get:
+      operationId: config_v1_orgs_projects_tables_partitions_list
+      description: |-
+        Get partitions belonging to specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get partitions
+      parameters:
+      - in: query
+        name: max_timestamp_after
+        schema:
+          type: string
+          format: date-time
+        description: The latest timestamp of the contiguous time-series data held
+          by this partition.
+      - in: query
+        name: max_timestamp_before
+        schema:
+          type: string
+          format: date-time
+        description: The latest timestamp of the contiguous time-series data held
+          by this partition.
+      - in: query
+        name: min_timestamp_after
+        schema:
+          type: string
+          format: date-time
+        description: The earliest timestamp of the contiguous time-series data held
+          by this partition.
+      - in: query
+        name: min_timestamp_before
+        schema:
+          type: string
+          format: date-time
+        description: The earliest timestamp of the contiguous time-series data held
+          by this partition.
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: project
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: query
+        name: root_path
+        schema:
+          type: string
+        description: Filter by root_path from catalog
+      - in: query
+        name: shard_key
+        schema:
+          type: string
+        description: Shard key
+      - in: query
+        name: table
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Tables
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCatalogList'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_tables_partitions_create
+      description: |-
+        Upload a brand new partition directly
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create partition
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: query
+        name: root_path
+        schema:
+          type: string
+        description: Filter by root_path from catalog
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Tables
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Catalog'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Catalog'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Catalog'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/partitions/delete_range/:
+    delete:
+      operationId: config_v1_orgs_projects_tables_partitions_delete_range_destroy
+      description: |-
+        Delete partitions belonging to specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete partitions
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: query
+        name: root_path
+        schema:
+          type: string
+        description: Filter by root_path from catalog
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Tables
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                DeletePartitions:
+                  value:
+                    success: true
+                    message: 1 deleted
+                  summary: delete partitions
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/query_options/:
+    get:
+      operationId: config_v1_orgs_projects_tables_query_options_retrieve
+      description: |-
+        Returns the query options setting for the specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get table query options hierarchy
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Query Options
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_tables_query_options_update
+      description: |-
+        Update the query options setting for the specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update table query options
+      externalDocs:
+        url: https://docs.hydrolix.io/docs/query-circuit-breakers
+        description: Query circuit breakers
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - config
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TableQueryOptions'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_projects_tables_query_options_partial_update
+      description: |-
+        Patch the query options setting for the specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch table query options
+      externalDocs:
+        url: https://docs.hydrolix.io/docs/query-circuit-breakers
+        description: Query circuit breakers
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - config
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTableQueryOptions'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/query_options_hierarchy/:
+    get:
+      operationId: config_v1_orgs_projects_tables_query_options_hierarchy_retrieve
+      description: |-
+        Returns the query options of every object in the hierarchy for the specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get table query options hierarchy
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Query Options
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SummarizedQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/sources/kafka/:
+    get:
+      operationId: config_v1_orgs_projects_tables_sources_kafka_list
+      description: |-
+        List the kafka sources for a table. Returns an array of sources
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get kafka sources
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kafka Sources
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/KafkaSource'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_tables_sources_kafka_create
+      description: |-
+        Create a kafka source for a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create kafka sources
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kafka Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KafkaSource'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KafkaSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/sources/kafka/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_tables_sources_kafka_retrieve
+      description: |-
+        Return a kafka source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get kafka source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kafka Sources
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KafkaSource'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_tables_sources_kafka_update
+      description: |-
+        Update a kafka source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update kafka source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kafka Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KafkaSource'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KafkaSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_projects_tables_sources_kafka_partial_update
+      description: |-
+        Patch a kafka source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch kafka source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kafka Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedKafkaSource'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KafkaSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_tables_sources_kafka_destroy
+      description: |-
+        Delete a kafka source
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete kafka source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kafka Sources
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/sources/kinesis/:
+    get:
+      operationId: config_v1_orgs_projects_tables_sources_kinesis_list
+      description: |-
+        List the kinesis sources for a table. Returns an array of sources
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get kinesis sources
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kinesis Sources
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/KinesisSource'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_tables_sources_kinesis_create
+      description: |-
+        Create a kinesis source for a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create kinesis source
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kinesis Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KinesisSource'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KinesisSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/sources/kinesis/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_tables_sources_kinesis_retrieve
+      description: |-
+        Return a kinesis source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get kinesis source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kinesis Sources
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KinesisSource'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_tables_sources_kinesis_update
+      description: |-
+        Update a kinesis source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update kinesis source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kinesis Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KinesisSource'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KinesisSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_projects_tables_sources_kinesis_partial_update
+      description: |-
+        Patch a kinesis source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch kinesis source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kinesis Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedKinesisSource'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KinesisSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_tables_sources_kinesis_destroy
+      description: |-
+        Delete a kinesis source
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete kinesis source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Kinesis Sources
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/sources/siem/:
+    get:
+      operationId: config_v1_orgs_projects_tables_sources_siem_list
+      description: |-
+        List the siem sources for a table. Returns an array of sources
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get siem sources
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Siem Sources
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SiemSource'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_tables_sources_siem_create
+      description: |-
+        Create a siem source for a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create siem source
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Siem Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SiemSource'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiemSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/sources/siem/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_tables_sources_siem_retrieve
+      description: |-
+        Return a siem source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get siem source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Siem Sources
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiemSource'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_tables_sources_siem_update
+      description: |-
+        Update a siem source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update siem source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Siem Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SiemSource'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiemSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_projects_tables_sources_siem_partial_update
+      description: |-
+        Patch a siem source belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch siem source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Siem Sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedSiemSource'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiemSource'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_tables_sources_siem_destroy
+      description: |-
+        Delete a siem source
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete siem source
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Siem Sources
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/stats/:
+    get:
+      operationId: config_v1_orgs_projects_tables_stats_retrieve
+      description: |-
+        Returns stats information for the specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get table stats
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Tables
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableStats'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/transforms/:
+    get:
+      operationId: config_v1_orgs_projects_tables_transforms_list
+      description: |-
+        List the transforms for a table. Returns an array of transforms
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get transforms
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Transforms
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Transform'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_tables_transforms_create
+      description: |-
+        Create a transform for a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create transform
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Transforms
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Transform'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transform'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                    primary_duplicate: Multiple fields were set as primary. Please
+                      make sure only 1 field is set as primary
+                    primary_required: A primary field was not specified. Please specify
+                      only one
+                    field_duplicate: column name {name} is repeated in multiple positions
+                    catch_all_duplicate: Multiple fields were set as catch_all. Please
+                      make sure only 1 field is set as catch_all
+                    catch_rejects_duplicate: Multiple fields were set as catch_rejects.
+                      Please make sure only 1 field is set as catch_rejects
+                    shard_key_duplicate: Multiple fields were set as shard_keys. Please
+                      make sure only 1 field is set as shard_key
+                    date_format_unkown: cannot find a matching format for {date_str}
+                    date_format_invalid: invalid date format {date_str}
+                    date_format_invalid_for_type: invalid format ({date_str}) for
+                      type ({date_type})
+                    date_format_missing: A timestamp must have a format field
+                    date_resolution_missing: A timestamp must have the resolution
+                      field set
+                    shard_key_not_string: A {type} field type cannot be used as a
+                      shard key. Only string field types are allowed
+                    treatment_invalid_for_type: invalid treatment ({treatment}) for
+                      type ({type}) for column name {name}
+                    type_invalid: Type {name} is invalid
+                    choice_invalid: '{choice} is not a valid choice'
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/transforms/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_tables_transforms_retrieve
+      description: |-
+        Return a transform instance belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get transfrom
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Transforms
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transform'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_tables_transforms_update
+      description: |-
+        Update a transform instance belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update transform
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Transforms
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Transform'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transform'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                    primary_duplicate: Multiple fields were set as primary. Please
+                      make sure only 1 field is set as primary
+                    primary_required: A primary field was not specified. Please specify
+                      only one
+                    field_duplicate: column name {name} is repeated in multiple positions
+                    catch_all_duplicate: Multiple fields were set as catch_all. Please
+                      make sure only 1 field is set as catch_all
+                    catch_rejects_duplicate: Multiple fields were set as catch_rejects.
+                      Please make sure only 1 field is set as catch_rejects
+                    shard_key_duplicate: Multiple fields were set as shard_keys. Please
+                      make sure only 1 field is set as shard_key
+                    date_format_unkown: cannot find a matching format for {date_str}
+                    date_format_invalid: invalid date format {date_str}
+                    date_format_invalid_for_type: invalid format ({date_str}) for
+                      type ({date_type})
+                    date_format_missing: A timestamp must have a format field
+                    date_resolution_missing: A timestamp must have the resolution
+                      field set
+                    shard_key_not_string: A {type} field type cannot be used as a
+                      shard key. Only string field types are allowed
+                    treatment_invalid_for_type: invalid treatment ({treatment}) for
+                      type ({type}) for column name {name}
+                    type_invalid: Type {name} is invalid
+                    choice_invalid: '{choice} is not a valid choice'
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_tables_transforms_destroy
+      description: |-
+        Delete a transform
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete transform
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Transforms
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/truncate/:
+    post:
+      operationId: config_v1_orgs_projects_tables_truncate_create
+      description: |-
+        Truncate the specified table id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Truncate table
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Tables
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TruncateTable'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TruncateTable'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/views/:
+    get:
+      operationId: config_v1_orgs_projects_tables_views_list
+      description: |-
+        List the views for a table. Returns an array of views
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get views
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Views
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/View'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_projects_tables_views_create
+      description: |-
+        Create a view for a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create view
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Views
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/View'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/View'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                    primary_duplicate: Multiple fields were set as primary. Please
+                      make sure only 1 field is set as primary
+                    primary_required: A primary field was not specified. Please specify
+                      only one
+                    field_duplicate: column name {name} is repeated in multiple positions
+                    treatment_invalid_for_type: invalid treatment ({treatment}) for
+                      type ({type}) in column {name}
+                    choice_invalid: '{choice} is not a valid choice'
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/views/{id}/:
+    get:
+      operationId: config_v1_orgs_projects_tables_views_retrieve
+      description: |-
+        Return a view instance belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get view
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Views
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/View'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_projects_tables_views_update
+      description: |-
+        Update a view instance belonging to a table
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update view
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Views
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/View'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/View'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                    primary_duplicate: Multiple fields were set as primary. Please
+                      make sure only 1 field is set as primary
+                    primary_required: A primary field was not specified. Please specify
+                      only one
+                    field_duplicate: column name {name} is repeated in multiple positions
+                    treatment_invalid_for_type: invalid treatment ({treatment}) for
+                      type ({type}) in column {name}
+                    choice_invalid: '{choice} is not a valid choice'
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_projects_tables_views_destroy
+      description: |-
+        Delete a view
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete view
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+      - in: path
+        name: table_id
+        schema:
+          type: string
+          format: uuid
+        description: Table ID
+        required: true
+      tags:
+      - Views
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/purgejobs/:
+    post:
+      operationId: config_v1_orgs_purgejobs_create
+      description: |-
+        Purge all jobs in the specified org id
+
+        **Permissions required**:
+        IsAuthenticated, AlterJobPermissions
+      summary: Purge jobs
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Batch Jobs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PurgeJob'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                JobStatus:
+                  value:
+                    purged_jobs:
+                    - 2
+                    - jobs.Job: 2
+                  summary: job status
+          description: Success
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/query_options/:
+    get:
+      operationId: config_v1_orgs_query_options_retrieve
+      description: |-
+        Returns the query options setting for the specified org id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get org query options
+      externalDocs:
+        url: https://docs.hydrolix.io/docs/query-circuit-breakers
+        description: Query circuit breakers
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Query Options
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrgQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_query_options_update
+      description: |-
+        Update the query options setting for the specified org id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update org query options
+      externalDocs:
+        url: https://docs.hydrolix.io/docs/query-circuit-breakers
+        description: Query circuit breakers
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Query Options
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrgQueryOptions'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrgQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_query_options_partial_update
+      description: |-
+        Patch the query options setting for the specified org id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch org query options
+      externalDocs:
+        url: https://docs.hydrolix.io/docs/query-circuit-breakers
+        description: Query circuit breakers
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Query Options
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedOrgQueryOptions'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrgQueryOptions'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/storages/:
+    get:
+      operationId: config_v1_orgs_storages_list
+      description: |-
+        List the storages in an organization. Returns an array of storages
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get storages
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HdxStorage'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_orgs_storages_create
+      description: |-
+        Create a storage in an organization.
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create storage
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HdxStorage'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HdxStorage'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/storages/{id}/:
+    get:
+      operationId: config_v1_orgs_storages_retrieve
+      description: |-
+        Returns the storage
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get storage
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HdxStorage'
+          description: ''
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_storages_update
+      description: |-
+        Updates the storage
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update storage
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HdxStorage'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HdxStorage'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_storages_partial_update
+      description: |-
+        Patch the storage
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch storage
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedHdxStorage'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HdxStorage'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_orgs_storages_destroy
+      description: |-
+        Deletes the storage
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete storage
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: Delete succeeded
+        '404':
+          description: Not found - URL is incorrect
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/storages/{id}/catalog/:
+    get:
+      operationId: config_v1_orgs_storages_catalog_list
+      description: |-
+        Returns a paginated list of all catalog entries referencing this storage
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get storage related catalog entries
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MetaTable'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/storages/{id}/related_resources/:
+    get:
+      operationId: config_v1_orgs_storages_related_resources_list
+      description: |-
+        Returns a count of the related tables and catalog entries for the referenced storage
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get count storage related resources
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MetaTable'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/storages/{id}/tables/:
+    get:
+      operationId: config_v1_orgs_storages_tables_list
+      description: |-
+        Returns a paginated list of all tables using this storage
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get storage related tables
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Storages
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MetaTable'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{org_id}/summary/:
+    get:
+      operationId: config_v1_orgs_summary_retrieve
+      description: "Returns a summary for the specified org id \n\n**Permissions required**:\n\
+        IsAuthenticated\nOrgSummaryPermissions"
+      summary: Get org summary
+      parameters:
+      - in: path
+        name: org_id
+        schema:
+          type: string
+          format: uuid
+        description: Organization ID
+        required: true
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrgSummary'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{id}/:
+    get:
+      operationId: config_v1_orgs_retrieve
+      description: |-
+        Return the specified org id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get org
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Org'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_orgs_update
+      description: |-
+        Update the specified org id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update org
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Orgs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Org'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Org'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_orgs_partial_update
+      description: |-
+        Patch the specified org id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch org
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Orgs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedOrg'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Org'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{id}/activity/:
+    get:
+      operationId: config_v1_orgs_activity_retrieve
+      description: |-
+        Return a list of the different actions that have been performed in the org
+
+        **Permissions required**:
+        AllowAny
+      summary: Get org activity
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedActivityList'
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/orgs/{id}/config_blob/:
+    get:
+      operationId: config_v1_orgs_config_blob_retrieve
+      description: Get the contents of the currently published config. This returns
+        the active config that is published in the config bucket, and it may not reflect
+        the current state represented by the API.
+      summary: Get config file contents
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Orgs
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Org'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/password_reset_confirm/:
+    post:
+      operationId: config_v1_password_reset_confirm_create
+      description: |-
+        Password reset
+
+        **Permissions required**:
+        AllowAny
+      summary: Reset password confirm
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetConfirm'
+        required: true
+      security:
+      - {}
+      responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - Check to make sure the passwords match and the
+            token and uuidb64 are correct
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          description: Success
+  /config/v1/pools/:
+    get:
+      operationId: config_v1_pools_list
+      description: |-
+        Get pools
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get pools
+      tags:
+      - Pools
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SwaggerPool'
+          description: ''
+    post:
+      operationId: config_v1_pools_create
+      description: |-
+        Create pool
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create pool
+      tags:
+      - Pools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SwaggerPool'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SwaggerPool'
+          description: ''
+  /config/v1/pools/{id}/:
+    get:
+      operationId: config_v1_pools_retrieve
+      description: |-
+        Get pool
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get pool
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Pools
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SwaggerPool'
+          description: ''
+    put:
+      operationId: config_v1_pools_update
+      description: |-
+        Update pool
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update pool
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Pools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SwaggerPool'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SwaggerPool'
+          description: ''
+    patch:
+      operationId: config_v1_pools_partial_update
+      description: |-
+        Patch pool
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch pool
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Pools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedSwaggerPool'
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SwaggerPool'
+          description: ''
+    delete:
+      operationId: config_v1_pools_destroy
+      description: |-
+        Delete pool
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete pool
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Pools
+      security:
+      - Authentication: []
+      responses:
+        '400':
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '204':
+          description: No response body
+  /config/v1/pools/ingest_endpoints/:
+    get:
+      operationId: config_v1_pools_ingest_endpoints_retrieve
+      description: |-
+        List the URLs of available ingest heads
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get ingest endpoints
+      tags:
+      - Pools
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                IngestEndpoints:
+                  value:
+                    default: string
+                    intake-head: string
+                    stream-head: string
+                  summary: ingest endpoints
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/pools/reset_redpanda/:
+    post:
+      operationId: config_v1_pools_reset_redpanda_create
+      description: |-
+        Reset the redpanda offset
+
+        This special action is only here so it has the url /pools
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Reset redpanda
+      tags:
+      - Pools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pool'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/reset_password/:
+    post:
+      operationId: config_v1_reset_password_create
+      description: |-
+        Use your email to get a reset password link
+
+        **Permissions required**:
+        AllowAny
+      summary: Reset password
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordReset'
+        required: true
+      security:
+      - {}
+      responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+        '200':
+          description: Success
+  /config/v1/roles/:
+    get:
+      operationId: config_v1_roles_list
+      description: |-
+        Get role
+
+        **Permissions required**:
+        IsAuthenticated, ('add_user', 'remove_user')
+      summary: List roles
+      tags:
+      - Roles
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Role'
+          description: ''
+    post:
+      operationId: config_v1_roles_create
+      description: |-
+        Create role
+
+        **Permissions required**:
+        IsAuthenticated, ('add_user', 'remove_user')
+      summary: Create role
+      tags:
+      - Roles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Role'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Role'
+          description: ''
+  /config/v1/roles/{id}/:
+    get:
+      operationId: config_v1_roles_retrieve
+      description: |-
+        Get role
+
+        **Permissions required**:
+        IsAuthenticated, ('add_user', 'remove_user')
+      summary: Get role
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this role.
+        required: true
+      tags:
+      - Roles
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Role'
+          description: ''
+    put:
+      operationId: config_v1_roles_update
+      description: |-
+        Update role
+
+        **Permissions required**:
+        IsAuthenticated, ('add_user', 'remove_user')
+      summary: Update role
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this role.
+        required: true
+      tags:
+      - Roles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Role'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Role'
+          description: ''
+    patch:
+      operationId: config_v1_roles_partial_update
+      description: |-
+        Patch role
+
+        **Permissions required**:
+        IsAuthenticated, ('add_user', 'remove_user')
+      summary: Patch role
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this role.
+        required: true
+      tags:
+      - Roles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRole'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Role'
+          description: ''
+    delete:
+      operationId: config_v1_roles_destroy
+      description: |-
+        Delete role
+
+        **Permissions required**:
+        IsAuthenticated, ('add_user', 'remove_user')
+      summary: Delete role
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this role.
+        required: true
+      tags:
+      - Roles
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: No response body
+  /config/v1/roles/{id}/add_user/:
+    post:
+      operationId: config_v1_roles_add_user_create
+      description: |-
+        Add one or multiple users to specified role id
+
+        **Permissions required**:
+        IsAuthenticated, ('add_user', 'remove_user')
+      summary: Add user to role
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this role.
+        required: true
+      tags:
+      - Roles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Role'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                AddUser:
+                  value:
+                    success: true
+                    message: 2 users added to role
+                  summary: add user
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/roles/{id}/remove_user/:
+    post:
+      operationId: config_v1_roles_remove_user_create
+      description: |-
+        Remove one or multiple users from specified role id
+
+        **Permissions required**:
+        IsAuthenticated, ('add_user', 'remove_user')
+      summary: Remove user from role
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this role.
+        required: true
+      tags:
+      - Roles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Role'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                AddUser:
+                  value:
+                    success: true
+                    message: 2 were removed from role
+                  summary: add user
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/roles/permissions/:
+    get:
+      operationId: config_v1_roles_permissions_retrieve
+      description: "Return a list of the permissions for each scope type \n\n**Permissions\
+        \ required**:\nIsAuthenticated"
+      summary: Get permissions
+      tags:
+      - Roles
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                AddUser:
+                  value:
+                  - scope_type: string
+                    permissions:
+                    - string
+                    - string
+                  - scope_type: string
+                    permissions:
+                    - string
+                    - string
+                  summary: add user
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/service_accounts/:
+    get:
+      operationId: config_v1_service_accounts_list
+      description: List service accounts
+      summary: List service accounts
+      tags:
+      - Service Accounts
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServiceAccount'
+          description: ''
+    post:
+      operationId: config_v1_service_accounts_create
+      description: |-
+        Create a service account
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create service account
+      tags:
+      - Service Accounts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceAccount'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceAccount'
+          description: ''
+  /config/v1/service_accounts/{uuid}/:
+    get:
+      operationId: config_v1_service_accounts_retrieve
+      description: Retrieve service account
+      summary: Retrieve service account
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this service account.
+        required: true
+      tags:
+      - Service Accounts
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceAccount'
+          description: ''
+    put:
+      operationId: config_v1_service_accounts_update
+      description: Update service account
+      summary: Update service account
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this service account.
+        required: true
+      tags:
+      - Service Accounts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceAccount'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceAccount'
+          description: ''
+    patch:
+      operationId: config_v1_service_accounts_partial_update
+      description: Partial update service account
+      summary: Partial update service account
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this service account.
+        required: true
+      tags:
+      - Service Accounts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedServiceAccount'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceAccount'
+          description: ''
+    delete:
+      operationId: config_v1_service_accounts_destroy
+      description: Delete service account
+      summary: Delete service account
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this service account.
+        required: true
+      tags:
+      - Service Accounts
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: No response body
+  /config/v1/service_accounts/{uuid}/tokens/:
+    post:
+      operationId: config_v1_service_accounts_tokens_create
+      description: |-
+        Generate tokens for the service account. Note: does not revoke previous tokens. Service account must be deleted
+        to revoke tokens.
+      parameters:
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this service account.
+        required: true
+      tags:
+      - Service Accounts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceAccount'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceAccount'
+          description: ''
+  /config/v1/tasks/:
+    get:
+      operationId: config_v1_tasks_list
+      description: |-
+        Return a list of tasks
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Get tasks
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - Tasks
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedProcrastinateTaskList'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/tasks/{id}/:
+    get:
+      operationId: config_v1_tasks_retrieve
+      description: |-
+        Returns a task specified by the id
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Get task
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this procrastinate job.
+        required: true
+      tags:
+      - Tasks
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailProcrastinateTask'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/tasks/clean/:
+    post:
+      operationId: config_v1_tasks_clean_create
+      description: |-
+        Clean any tasks that have been in a succeeded state for more than 72 hours.
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Clean older tasks
+      tags:
+      - Tasks
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                CleanOlderTasks:
+                  value:
+                    message: queued
+                  summary: clean older tasks
+          description: Success
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/tasks/events/:
+    get:
+      operationId: config_v1_tasks_events_list
+      description: |-
+        Return a list of tasks events
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Get tasks events
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - Tasks
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedProcrastinateEventList'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/tasks/events/{id}/:
+    get:
+      operationId: config_v1_tasks_events_retrieve
+      description: |-
+        Returns a task event specified by the id
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Get tasks event
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this procrastinate event.
+        required: true
+      tags:
+      - Tasks
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailProcrastinateEvent'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/transform_templates/:
+    get:
+      operationId: config_v1_transform_templates_list
+      description: |-
+        Return a list of transform templates
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get transform templates
+      tags:
+      - Transform Templates
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TransformTemplate'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    post:
+      operationId: config_v1_transform_templates_create
+      description: |-
+        Create transform template
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Create transform template
+      tags:
+      - Transform Templates
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransformTemplate'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransformTemplate'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/transform_templates/{id}/:
+    get:
+      operationId: config_v1_transform_templates_retrieve
+      description: |-
+        Get transform template for the specified id
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Get transform template
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this transform template.
+        required: true
+      tags:
+      - Transform Templates
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransformTemplate'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    put:
+      operationId: config_v1_transform_templates_update
+      description: |-
+        Update transform template
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Update transform template
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this transform template.
+        required: true
+      tags:
+      - Transform Templates
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransformTemplate'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransformTemplate'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    patch:
+      operationId: config_v1_transform_templates_partial_update
+      description: |-
+        Patch transform template
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Patch transform template
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this transform template.
+        required: true
+      tags:
+      - Transform Templates
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTransformTemplate'
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransformTemplate'
+          description: ''
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_transform_templates_destroy
+      description: |-
+        Delete transform template
+
+        **Permissions required**:
+        IsAuthenticated
+      summary: Delete transform template
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this transform template.
+        required: true
+      tags:
+      - Transform Templates
+      security:
+      - Authentication: []
+      responses:
+        '204':
+          description: No response body
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/users/:
+    get:
+      operationId: config_v1_users_list
+      description: |-
+        Return all users that an admin can see
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: List users
+      tags:
+      - Users
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/users/{id}/:
+    get:
+      operationId: config_v1_users_retrieve
+      description: |-
+        Return a read only user for admin to view
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Get user
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Users
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+    delete:
+      operationId: config_v1_users_destroy
+      description: |-
+        Deletes user
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Delete user
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Users
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/users/{id}/add_roles/:
+    post:
+      operationId: config_v1_users_add_roles_create
+      description: |-
+        Add roles to the specified user id
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Add roles to user
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Users
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                AddRoles:
+                  value:
+                    success: true
+                    message: 2 roles added to user test@hydrolix.io
+                  summary: add roles
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/users/{id}/remove_roles/:
+    post:
+      operationId: config_v1_users_remove_roles_create
+      description: |-
+        Remove roles from the specified user id
+
+        **Permissions required**:
+        IsAuthenticated, UserPermissions
+      summary: Remove roles from user
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: Resource ID
+        required: true
+      tags:
+      - Users
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        required: true
+      security:
+      - Authentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                AddRoles:
+                  value:
+                    success: true
+                    message: 2 roles removed from user test@hydrolix.io
+                  summary: add roles
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                Validation:
+                  value:
+                    parameter_missing: This field is required
+                    parameter_unknown: This is not a parameter that can be used
+                    name_exists: The name ({name}) already exists on the specified
+                      {parent} in the url
+                  summary: validation
+          description: Bad Request - The request was unacceptable, often due to missing
+            a required parameter
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+  /config/v1/users/current/:
+    get:
+      operationId: config_v1_users_current_retrieve
+      description: Returns information on the currently authenticated user, useful
+        for getting information on the token being used.
+      summary: Return information about the authenticated user.
+      tags:
+      - Users
+      security:
+      - Authentication: []
+      responses:
+        '401':
+          description: Unauthorized - Invalid or no token was sent
+        '403':
+          description: Forbidden - The token sent does not have permissions to perform
+            the request
+        '404':
+          description: Not found - URL is incorrect
+        '405':
+          description: Method Not Allowed - HTTP method used is not allowed
+        '500':
+          description: Server Error - Something went wrong on our end
+components:
+  schemas:
+    Activity:
+      type: object
+      properties:
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        action:
+          type: string
+          maxLength: 256
+        org:
+          type: string
+          format: uuid
+        log:
+          nullable: true
+      required:
+      - action
+      - created
+      - org
+    AlterJob:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/AlterJobSettings'
+        status:
+          enum:
+          - ready
+          - running
+          - failed
+          - pending
+          - done
+          - canceled
+          - unknown
+          type: string
+          description: |-
+            * `ready` - READY
+            * `running` - RUNNING
+            * `failed` - FAILED
+            * `pending` - PENDING
+            * `done` - DONE
+            * `canceled` - CANCELED
+            * `unknown` - UNKNOWN
+          x-spec-enum-id: caa1a364bd0b0752
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        details:
+          readOnly: true
+        created_by_user:
+          allOf:
+          - $ref: '#/components/schemas/UserSimple'
+          readOnly: true
+      required:
+      - created
+      - created_by_user
+      - details
+      - modified
+      - org
+      - settings
+      - status
+      - type
+    AlterJobSettings:
+      type: object
+      properties:
+        project_id:
+          type: string
+          format: uuid
+        project_name:
+          type: string
+          nullable: true
+          readOnly: true
+        table_id:
+          type: string
+          format: uuid
+        table_name:
+          type: string
+          nullable: true
+          readOnly: true
+        min_timestamp:
+          type: integer
+        max_timestamp:
+          type: integer
+        shard_key:
+          type: string
+          nullable: true
+        sql_stmt:
+          type: string
+        reliable_update:
+          type: boolean
+      required:
+      - project_id
+      - project_name
+      - reliable_update
+      - sql_stmt
+      - table_id
+      - table_name
+    AuthLog:
+      type: object
+      properties:
+        time:
+          type: integer
+        type:
+          type: string
+        realmId:
+          type: string
+        clientId:
+          type: string
+        userId:
+          type: string
+        ipAddress:
+          type: string
+        error:
+          type: string
+        details:
+          $ref: '#/components/schemas/AuthLogDetails'
+      required:
+      - clientId
+      - details
+      - error
+      - ipAddress
+      - realmId
+      - time
+      - type
+      - userId
+    AuthLogDetails:
+      type: object
+      properties:
+        auth_method:
+          type: string
+        grant_type:
+          type: string
+        client_auth_method:
+          type: string
+        username:
+          type: string
+      required:
+      - auth_method
+      - client_auth_method
+      - grant_type
+      - username
+    BatchJob:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/BatchJobSettings'
+        status:
+          enum:
+          - ready
+          - running
+          - failed
+          - pending
+          - done
+          - canceled
+          - unknown
+          type: string
+          description: |-
+            * `ready` - READY
+            * `running` - RUNNING
+            * `failed` - FAILED
+            * `pending` - PENDING
+            * `done` - DONE
+            * `canceled` - CANCELED
+            * `unknown` - UNKNOWN
+          x-spec-enum-id: caa1a364bd0b0752
+          readOnly: true
+        type:
+          type: string
+          maxLength: 256
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        details:
+          readOnly: true
+        created_by_user:
+          allOf:
+          - $ref: '#/components/schemas/UserSimple'
+          readOnly: true
+      required:
+      - created
+      - created_by_user
+      - details
+      - modified
+      - org
+      - settings
+      - status
+      - type
+    BatchJobSettings:
+      type: object
+      properties:
+        max_active_partitions:
+          type: integer
+          default: 576
+        max_rows_per_partition:
+          type: integer
+          default: 33554432
+        max_minutes_per_partition:
+          type: integer
+          default: 360
+        input_concurrency:
+          type: integer
+          default: 1
+        input_aggregation:
+          type: integer
+          default: 536870912
+        max_files:
+          type: integer
+          default: 0
+        dry_run:
+          type: boolean
+          default: false
+        regex_filter:
+          type: string
+          default: ''
+        source:
+          $ref: '#/components/schemas/BatchSource'
+      required:
+      - source
+    BatchSource:
+      type: object
+      properties:
+        transform:
+          type: string
+          maxLength: 256
+        table:
+          type: string
+        settings:
+          $ref: '#/components/schemas/BatchSourceSettings'
+      required:
+      - settings
+      - table
+    BatchSourceSettings:
+      type: object
+      properties:
+        bucket_name:
+          type: string
+        bucket_path:
+          type: string
+          default: /
+        region:
+          type: string
+        endpoint:
+          type: string
+        cloud:
+          type: string
+        credential_id:
+          type: string
+          format: uuid
+          nullable: true
+        account_name:
+          type: string
+          readOnly: true
+      required:
+      - account_name
+      - bucket_name
+      - cloud
+    Catalog:
+      type: object
+      properties:
+        data_path:
+          type: string
+        root_path_name:
+          type: string
+          nullable: true
+          readOnly: true
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        table:
+          type: string
+          format: uuid
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+        modified:
+          type: string
+          format: date-time
+        min_timestamp:
+          type: string
+          format: date-time
+          nullable: true
+        max_timestamp:
+          type: string
+          format: date-time
+          nullable: true
+        manifest_size:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+        data_size:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+        index_size:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+        root_path:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+        rows:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+        mem_size:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+        metadata:
+          nullable: true
+        shard_key:
+          type: string
+          maxLength: 16
+        storage_id:
+          type: string
+          format: uuid
+          nullable: true
+        lock:
+          type: integer
+          nullable: true
+      required:
+      - active
+      - created
+      - data_path
+      - mem_size
+      - modified
+      - project
+      - root_path
+      - root_path_name
+      - rows
+      - shard_key
+      - storage_id
+      - table
+    ChangePassword:
+      type: object
+      properties:
+        current_password:
+          type: string
+        new_password:
+          type: string
+        confirm_password:
+          type: string
+      required:
+      - confirm_password
+      - current_password
+      - new_password
+    Column:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+        type:
+          enum:
+          - datetime
+          - datetime64
+          - double
+          - uint8
+          - uint32
+          - uint64
+          - int8
+          - int32
+          - int64
+          - string
+          - array
+          - map
+          - json
+          - epoch
+          - bool
+          - boolean
+          type: string
+          description: |-
+            * `datetime` - datetime
+            * `datetime64` - datetime64
+            * `double` - double
+            * `uint8` - uint8
+            * `uint32` - uint32
+            * `uint64` - uint64
+            * `int8` - int8
+            * `int32` - uint32
+            * `int64` - int64
+            * `string` - string
+            * `array` - array
+            * `map` - map
+            * `json` - json
+            * `epoch` - epoch
+            * `bool` - bool
+            * `boolean` - boolean
+          x-spec-enum-id: 0a7530e284de2ad1
+        current_name:
+          type: string
+        past_names:
+          type: array
+          items:
+            type: string
+        primary:
+          type: boolean
+        index:
+          type: boolean
+        resolution:
+          enum:
+          - s
+          - ms
+          - ''
+          type: string
+          description: "* `s` - s\n* `ms` - ms\n* `` - "
+          x-spec-enum-id: a2e0d4fd779882f9
+        elements: {}
+      required:
+      - current_name
+      - id
+      - index
+      - name
+      - type
+    Credential:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        type:
+          type: string
+        cloud:
+          type: string
+          nullable: true
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        details: {}
+        attached_resources:
+          type: object
+          additionalProperties: {}
+          readOnly: true
+        publish_task_id:
+          type: integer
+          readOnly: true
+      required:
+      - attached_resources
+      - created
+      - modified
+      - name
+      - org
+      - publish_task_id
+      - type
+      - url
+    DataType:
+      type: object
+      properties:
+        type:
+          enum:
+          - datetime
+          - datetime64
+          - double
+          - uint8
+          - uint32
+          - uint64
+          - int8
+          - int32
+          - int64
+          - string
+          - array
+          - map
+          - json
+          - epoch
+          - bool
+          - boolean
+          type: string
+          description: |-
+            * `datetime` - datetime
+            * `datetime64` - datetime64
+            * `double` - double
+            * `uint8` - uint8
+            * `uint32` - uint32
+            * `uint64` - uint64
+            * `int8` - int8
+            * `int32` - int32
+            * `int64` - int64
+            * `string` - string
+            * `array` - array
+            * `map` - map
+            * `json` - json
+            * `epoch` - epoch
+            * `bool` - bool
+            * `boolean` - boolean
+          x-spec-enum-id: f0ab41aa02fd9259
+        index:
+          type: boolean
+        index_options:
+          $ref: '#/components/schemas/DataTypeIndexOptions'
+        denullify:
+          type: boolean
+        virtual:
+          type: boolean
+        primary:
+          type: boolean
+        catch_all:
+          type: boolean
+        catch_rejects:
+          type: boolean
+        sql_expression:
+          type: string
+        null_values:
+          type: array
+          items:
+            type: string
+        ignore:
+          type: boolean
+        limits: {}
+        format:
+          type: string
+          nullable: true
+        resolution:
+          enum:
+          - milliseconds
+          - millisecond
+          - millis
+          - milli
+          - ms
+          - seconds
+          - second
+          - secs
+          - sec
+          - s
+          - null
+          type: string
+          description: |-
+            * `milliseconds` - milliseconds
+            * `millisecond` - millisecond
+            * `millis` - millis
+            * `milli` - milli
+            * `ms` - ms
+            * `seconds` - seconds
+            * `second` - second
+            * `secs` - secs
+            * `sec` - sec
+            * `s` - s
+          x-spec-enum-id: 2235386374b0a96f
+          nullable: true
+        default:
+          nullable: true
+        script:
+          type: string
+          nullable: true
+        elements:
+          type: array
+          items:
+            $ref: '#/components/schemas/ElementsDataType'
+      required:
+      - type
+    DataTypeIndexOptions:
+      type: object
+      properties:
+        fulltext:
+          type: boolean
+          default: false
+        major_separators:
+          type: string
+        minor_separators:
+          type: string
+    DataTypeSource:
+      type: object
+      properties:
+        from_input_fields:
+          type: array
+          items:
+            type: string
+        from_input_field:
+          type: string
+        from_input_index:
+          type: integer
+        from_json_pointers:
+          type: array
+          items:
+            type: string
+        from_automatic_value:
+          type: string
+    DefaultOrgQueryOptions:
+      type: object
+      description: https://docs.hydrolix.io/docs/query-circuit-breakers
+      properties:
+        hdx_query_max_rows:
+          type: integer
+        hdx_query_max_attempts:
+          type: integer
+        hdx_query_distributed_aggregation_memory_efficient:
+          type: integer
+        hdx_query_max_bytes_before_external_group_by:
+          type: integer
+        hdx_query_max_bytes_before_external_sort:
+          type: integer
+        hdx_query_max_result_bytes:
+          type: integer
+          minimum: 10000
+        hdx_query_max_result_rows:
+          type: integer
+        hdx_query_max_timerange_sec:
+          type: integer
+        hdx_query_timerange_required:
+          type: boolean
+        hdx_query_max_partitions:
+          type: integer
+        hdx_query_max_execution_time:
+          type: integer
+        hdx_query_max_columns_to_read:
+          type: integer
+        hdx_query_max_memory_usage:
+          type: integer
+        hdx_query_catalog_timeout_ms:
+          type: integer
+        hdx_query_max_peers:
+          type: integer
+        hdx_query_pool_name:
+          type: string
+        hdx_query_max_streams:
+          type: integer
+        hdx_query_max_concurrent_partitions:
+          type: integer
+        hdx_query_output_file_enabled:
+          type: boolean
+        hdx_query_output_format:
+          type: string
+        hdx_query_unlimited_cnf:
+          type: integer
+          maximum: 1
+    DefaultProjectQueryOptions:
+      type: object
+      description: https://docs.hydrolix.io/docs/query-circuit-breakers
+      properties:
+        hdx_query_max_rows:
+          type: integer
+        hdx_query_max_attempts:
+          type: integer
+        hdx_query_distributed_aggregation_memory_efficient:
+          type: integer
+        hdx_query_max_bytes_before_external_group_by:
+          type: integer
+        hdx_query_max_bytes_before_external_sort:
+          type: integer
+        hdx_query_max_result_bytes:
+          type: integer
+        hdx_query_max_result_rows:
+          type: integer
+        hdx_query_max_timerange_sec:
+          type: integer
+        hdx_query_timerange_required:
+          type: boolean
+        hdx_query_max_partitions:
+          type: integer
+        hdx_query_max_execution_time:
+          type: integer
+        hdx_query_max_columns_to_read:
+          type: integer
+        hdx_query_max_memory_usage:
+          type: integer
+        hdx_query_catalog_timeout_ms:
+          type: integer
+        hdx_query_max_peers:
+          type: integer
+        hdx_query_pool_name:
+          type: string
+        hdx_query_max_streams:
+          type: integer
+        hdx_query_max_concurrent_partitions:
+          type: integer
+        hdx_query_output_file_enabled:
+          type: boolean
+        hdx_query_output_format:
+          type: string
+        hdx_query_unlimited_cnf:
+          type: integer
+          maximum: 1
+    DefaultTableQueryOptions:
+      type: object
+      description: https://docs.hydrolix.io/docs/query-circuit-breakers
+      properties:
+        hdx_query_max_rows:
+          type: integer
+        hdx_query_max_attempts:
+          type: integer
+        hdx_query_distributed_aggregation_memory_efficient:
+          type: integer
+        hdx_query_max_bytes_before_external_group_by:
+          type: integer
+        hdx_query_max_bytes_before_external_sort:
+          type: integer
+        hdx_query_max_result_bytes:
+          type: integer
+        hdx_query_max_result_rows:
+          type: integer
+        hdx_query_max_timerange_sec:
+          type: integer
+        hdx_query_timerange_required:
+          type: boolean
+        hdx_query_max_partitions:
+          type: integer
+        hdx_query_max_execution_time:
+          type: integer
+        hdx_query_max_columns_to_read:
+          type: integer
+        hdx_query_max_memory_usage:
+          type: integer
+        hdx_query_catalog_timeout_ms:
+          type: integer
+        hdx_query_max_peers:
+          type: integer
+        hdx_query_pool_name:
+          type: string
+        hdx_query_max_streams:
+          type: integer
+        hdx_query_max_concurrent_partitions:
+          type: integer
+        hdx_query_output_file_enabled:
+          type: boolean
+        hdx_query_output_format:
+          type: string
+        hdx_query_unlimited_cnf:
+          type: integer
+          maximum: 1
+    DetailProcrastinateEvent:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        type:
+          enum:
+          - deferred
+          - started
+          - deferred_for_retry
+          - failed
+          - succeeded
+          - cancelled
+          - abort_requested
+          - aborted
+          - scheduled
+          type: string
+          description: |-
+            * `deferred` - deferred
+            * `started` - started
+            * `deferred_for_retry` - deferred_for_retry
+            * `failed` - failed
+            * `succeeded` - succeeded
+            * `cancelled` - cancelled
+            * `abort_requested` - abort_requested
+            * `aborted` - aborted
+            * `scheduled` - scheduled
+          x-spec-enum-id: ce47322d727b7c78
+        job:
+          allOf:
+          - $ref: '#/components/schemas/ProcrastinateTask'
+          readOnly: true
+        at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - id
+      - job
+      - type
+    DetailProcrastinateTask:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        queue_name:
+          type: string
+          maxLength: 128
+        task_name:
+          type: string
+          maxLength: 128
+        priority:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        lock:
+          type: string
+          nullable: true
+        args: {}
+        status:
+          enum:
+          - todo
+          - doing
+          - succeeded
+          - failed
+          - cancelled
+          - aborting
+          - aborted
+          type: string
+          description: |-
+            * `todo` - todo
+            * `doing` - doing
+            * `succeeded` - succeeded
+            * `failed` - failed
+            * `cancelled` - cancelled
+            * `aborting` - aborting
+            * `aborted` - aborted
+          x-spec-enum-id: 0f31f28290bff67e
+        scheduled_at:
+          type: string
+          format: date-time
+          nullable: true
+        attempts:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        queueing_lock:
+          type: string
+          nullable: true
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcrastinateEvent'
+          readOnly: true
+      required:
+      - args
+      - attempts
+      - events
+      - id
+      - priority
+      - queue_name
+      - status
+      - task_name
+    Dictionary:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Dictionary's name value
+          maxLength: 64
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+          description: project's id where the dictionary is created.
+        description:
+          type: string
+          nullable: true
+          description: The description for the dictionary.
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/DictionarySettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - project
+      - publish_task_id
+      - settings
+      - url
+    DictionaryDatatype:
+      type: object
+      properties:
+        type:
+          enum:
+          - uint8
+          - uint32
+          - uint64
+          - int8
+          - int32
+          - int64
+          - double
+          - datetime
+          - datetime64
+          - string
+          - array
+          type: string
+          description: |-
+            * `uint8` - uint8
+            * `uint32` - uint32
+            * `uint64` - uint64
+            * `int8` - int8
+            * `int32` - int32
+            * `int64` - int64
+            * `double` - double
+            * `datetime` - datetime
+            * `datetime64` - datetime64
+            * `string` - string
+            * `array` - array
+          x-spec-enum-id: 008957a189d5a56c
+        elements:
+          type: array
+          items:
+            $ref: '#/components/schemas/DictionaryElementsDatatype'
+        denullify:
+          type: boolean
+          default: true
+      required:
+      - type
+    DictionaryElementsDatatype:
+      type: object
+      properties:
+        type:
+          type: string
+      required:
+      - type
+    DictionaryFile:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name for the file that will be uploaded.
+          maxLength: 256
+        file:
+          type: string
+          format: uri
+          writeOnly: true
+          description: The CSV file with the content to be added.
+      required:
+      - file
+    DictionaryGenerate:
+      type: object
+      properties:
+        sample:
+          type: string
+          writeOnly: true
+        format:
+          type: string
+          writeOnly: true
+          maxLength: 256
+        type:
+          enum:
+          - file
+          - text
+          type: string
+          description: |-
+            * `file` - file
+            * `text` - text
+          x-spec-enum-id: 2173a3aa7f9af6b5
+          writeOnly: true
+        delimiter:
+          type: string
+          writeOnly: true
+          default: ','
+          maxLength: 1
+        output_columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransformOutputColumns'
+          readOnly: true
+      required:
+      - format
+      - output_columns
+      - type
+    DictionaryOutputColumns:
+      type: object
+      properties:
+        name:
+          type: string
+        datatype:
+          $ref: '#/components/schemas/DictionaryDatatype'
+      required:
+      - datatype
+      - name
+    DictionarySettings:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: Name of the dictionary file.
+        layout:
+          enum:
+          - flat
+          - hashed
+          - sparse_hashed
+          - complex_key_hashed
+          - complex_key_sparse_hashed
+          - hashed_array
+          - complex_key_hashed_array
+          - range_hashed
+          - complex_key_range_hashed
+          - cache
+          - complex_key_cache
+          - ssd_cache
+          - complex_key_ssd_cache
+          - direct
+          - complex_key_direct
+          - ip_trie
+          - regexp_tree
+          type: string
+          x-spec-enum-id: bf6c2c074132cabd
+          description: |-
+            Will depend on if you want lookups to use a composite or singular column as key.
+
+            * `flat` - flat
+            * `hashed` - hashed
+            * `sparse_hashed` - sparse_hashed
+            * `complex_key_hashed` - complex_key_hashed
+            * `complex_key_sparse_hashed` - complex_key_sparse_hashed
+            * `hashed_array` - hashed_array
+            * `complex_key_hashed_array` - complex_key_hashed_array
+            * `range_hashed` - range_hashed
+            * `complex_key_range_hashed` - complex_key_range_hashed
+            * `cache` - cache
+            * `complex_key_cache` - complex_key_cache
+            * `ssd_cache` - ssd_cache
+            * `complex_key_ssd_cache` - complex_key_ssd_cache
+            * `direct` - direct
+            * `complex_key_direct` - complex_key_direct
+            * `ip_trie` - ip_trie
+            * `regexp_tree` - regexp_tree
+        lifetime_seconds:
+          type: integer
+          default: 5
+          description: How often ClickHouse refreshes the dictionary from the local
+            file.
+        output_columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/DictionaryOutputColumns'
+        dictionary_load_level:
+          type: array
+          items:
+            enum:
+            - ALL
+            - QUERY
+            - INTAKE
+            type: string
+            description: |-
+              * `ALL` - ALL
+              * `QUERY` - QUERY
+              * `INTAKE` - INTAKE
+            x-spec-enum-id: ffe2aaaa99d9d28d
+            default: ALL
+          default:
+          - ALL
+          description: Dictionary load level
+          minItems: 1
+        primary_key:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        format:
+          enum:
+          - TabSeparated
+          - TabSeparatedRaw
+          - TabSeparatedWithNames
+          - TabSeparatedWithNamesAndTypes
+          - TabSeparatedRawWithNames
+          - TabSeparatedRawWithNamesAndTypes
+          - CSV
+          - CSVWithNames
+          - CSVWithNamesAndTypes
+          - Values
+          - JSON
+          - JSONColumns
+          - JSONColumnsWithMetadata
+          - JSONCompact
+          - JSONEachRow
+          - JSONObjectEachRow
+          - TSKV
+          - LineAsString
+          - CustomSeparated
+          - CustomSeparatedWithNames
+          - CustomSeparatedWithNamesAndTypes
+          - BSONEachRow
+          - Native
+          - RawBLOB
+          - Regexp
+          type: string
+          x-spec-enum-id: adf3aa9adbbbc999
+          description: |-
+            The format of the dictionary file
+
+            * `TabSeparated` - TabSeparated
+            * `TabSeparatedRaw` - TabSeparatedRaw
+            * `TabSeparatedWithNames` - TabSeparatedWithNames
+            * `TabSeparatedWithNamesAndTypes` - TabSeparatedWithNamesAndTypes
+            * `TabSeparatedRawWithNames` - TabSeparatedRawWithNames
+            * `TabSeparatedRawWithNamesAndTypes` - TabSeparatedRawWithNamesAndTypes
+            * `CSV` - CSV
+            * `CSVWithNames` - CSVWithNames
+            * `CSVWithNamesAndTypes` - CSVWithNamesAndTypes
+            * `Values` - Values
+            * `JSON` - JSON
+            * `JSONColumns` - JSONColumns
+            * `JSONColumnsWithMetadata` - JSONColumnsWithMetadata
+            * `JSONCompact` - JSONCompact
+            * `JSONEachRow` - JSONEachRow
+            * `JSONObjectEachRow` - JSONObjectEachRow
+            * `TSKV` - TSKV
+            * `LineAsString` - LineAsString
+            * `CustomSeparated` - CustomSeparated
+            * `CustomSeparatedWithNames` - CustomSeparatedWithNames
+            * `CustomSeparatedWithNamesAndTypes` - CustomSeparatedWithNamesAndTypes
+            * `BSONEachRow` - BSONEachRow
+            * `Native` - Native
+            * `RawBLOB` - RawBLOB
+            * `Regexp` - Regexp
+      required:
+      - filename
+      - format
+      - layout
+      - output_columns
+      - primary_key
+    ElementsDataType:
+      type: object
+      properties:
+        type:
+          enum:
+          - datetime
+          - datetime64
+          - double
+          - uint8
+          - uint32
+          - uint64
+          - int8
+          - int32
+          - int64
+          - string
+          - array
+          - map
+          - json
+          - epoch
+          - bool
+          - boolean
+          type: string
+          description: |-
+            * `datetime` - datetime
+            * `datetime64` - datetime64
+            * `double` - double
+            * `uint8` - uint8
+            * `uint32` - uint32
+            * `uint64` - uint64
+            * `int8` - int8
+            * `int32` - int32
+            * `int64` - int64
+            * `string` - string
+            * `array` - array
+            * `map` - map
+            * `json` - json
+            * `epoch` - epoch
+            * `bool` - bool
+            * `boolean` - boolean
+          x-spec-enum-id: f0ab41aa02fd9259
+        index:
+          type: boolean
+        index_options:
+          $ref: '#/components/schemas/DataTypeIndexOptions'
+        denullify:
+          type: boolean
+        virtual:
+          type: boolean
+        primary:
+          type: boolean
+        catch_all:
+          type: boolean
+        catch_rejects:
+          type: boolean
+        sql_expression:
+          type: string
+        null_values:
+          type: array
+          items:
+            type: string
+        ignore:
+          type: boolean
+        limits: {}
+        format:
+          type: string
+          nullable: true
+        resolution:
+          enum:
+          - milliseconds
+          - millisecond
+          - millis
+          - milli
+          - ms
+          - seconds
+          - second
+          - secs
+          - sec
+          - s
+          - null
+          type: string
+          description: |-
+            * `milliseconds` - milliseconds
+            * `millisecond` - millisecond
+            * `millis` - millis
+            * `milli` - milli
+            * `ms` - ms
+            * `seconds` - seconds
+            * `second` - second
+            * `secs` - secs
+            * `sec` - sec
+            * `s` - s
+          x-spec-enum-id: 2235386374b0a96f
+          nullable: true
+        default:
+          nullable: true
+        script:
+          type: string
+          nullable: true
+        elements:
+          type: array
+          items:
+            $ref: '#/components/schemas/ElementsDataType'
+      required:
+      - type
+    Function:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        sql:
+          type: string
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        publish_task_id:
+          type: integer
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - project
+      - publish_task_id
+      - sql
+      - url
+    HdxStorage:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/HdxStorageSettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - org
+      - publish_task_id
+      - settings
+      - url
+    HdxStorageSettings:
+      type: object
+      properties:
+        bucket_name:
+          type: string
+        bucket_path:
+          type: string
+          default: /
+        region:
+          type: string
+        endpoint:
+          type: string
+        cloud:
+          type: string
+        credential_id:
+          type: string
+          format: uuid
+          nullable: true
+        account_name:
+          type: string
+          readOnly: true
+        is_default:
+          type: boolean
+          default: false
+        io_perf_mode:
+          enum:
+          - 0
+          - 1
+          - 2
+          - aggressive
+          - moderate
+          - relaxed
+          description: |-
+            * `0` - 0
+            * `1` - 1
+            * `2` - 2
+            * `aggressive` - aggressive
+            * `moderate` - moderate
+            * `relaxed` - relaxed
+          x-spec-enum-id: c35474dd60cf0dba
+      required:
+      - account_name
+      - bucket_name
+      - cloud
+    IdentityProvider:
+      type: object
+      properties:
+        alias:
+          type: string
+          description: The alias of the IDP, used with the `idp_hint` login query
+            parameter
+        display_name:
+          type: string
+          description: The friendly name of the IDP
+        provider_id:
+          type: string
+          description: The type of identity provider
+      required:
+      - alias
+      - display_name
+      - provider_id
+    Invite:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        org:
+          type: string
+          format: uuid
+        roles:
+          type: array
+          items:
+            type: string
+        password:
+          type: string
+        activate_user:
+          type: boolean
+          default: false
+        id:
+          type: integer
+          readOnly: true
+        status:
+          enum:
+          - pending
+          - claimed
+          type: string
+          description: |-
+            * `pending` - Pending
+            * `claimed` - Claimed
+          x-spec-enum-id: 2782253ec10b7baa
+        inviter:
+          type: string
+          format: uuid
+          readOnly: true
+        invitee:
+          type: string
+          format: uuid
+          readOnly: true
+        audit:
+          type: boolean
+          readOnly: true
+      required:
+      - audit
+      - email
+      - id
+      - invitee
+      - inviter
+      - org
+      - roles
+    InviteURLResponse:
+      type: object
+      properties:
+        invite_url:
+          type: string
+          format: uri
+      required:
+      - invite_url
+    K8sDeployment:
+      type: object
+      properties:
+        current_replicas:
+          type: string
+          readOnly: true
+        replicas:
+          type: string
+        cpu:
+          type: string
+        memory:
+          type: string
+        storage:
+          type: string
+          readOnly: true
+        scale_profile:
+          type: string
+        service:
+          enum:
+          - kafka-peer
+          - operator
+          - intake-api
+          - tooling
+          - zookeeper
+          - autoingest
+          - alter-head
+          - traefik
+          - kinesis-kcl-peer
+          - merge-peer-i
+          - intake-head
+          - stream-head
+          - merge-cleanup
+          - merge-peer
+          - pushgateway
+          - redpanda
+          - akamai-siem-peer
+          - query-head
+          - prometheus
+          - merge-peer-ii
+          - alter-peer
+          - turbine-api
+          - stream-peer
+          - minio
+          - merge-peer-iii
+          - kinesis-peer
+          - ui
+          - reaper
+          - rabbitmq
+          - decay
+          - usagemeter
+          - batch-peer
+          - version
+          - keycloak
+          - batch-head
+          - validator
+          - query-peer
+          - postgres
+          - merge-head
+          - null
+          type: string
+          description: |-
+            * `kafka-peer` - kafka-peer
+            * `operator` - operator
+            * `intake-api` - intake-api
+            * `tooling` - tooling
+            * `zookeeper` - zookeeper
+            * `autoingest` - autoingest
+            * `alter-head` - alter-head
+            * `traefik` - traefik
+            * `kinesis-kcl-peer` - kinesis-kcl-peer
+            * `merge-peer-i` - merge-peer-i
+            * `intake-head` - intake-head
+            * `stream-head` - stream-head
+            * `merge-cleanup` - merge-cleanup
+            * `merge-peer` - merge-peer
+            * `pushgateway` - pushgateway
+            * `redpanda` - redpanda
+            * `akamai-siem-peer` - akamai-siem-peer
+            * `query-head` - query-head
+            * `prometheus` - prometheus
+            * `merge-peer-ii` - merge-peer-ii
+            * `alter-peer` - alter-peer
+            * `turbine-api` - turbine-api
+            * `stream-peer` - stream-peer
+            * `minio` - minio
+            * `merge-peer-iii` - merge-peer-iii
+            * `kinesis-peer` - kinesis-peer
+            * `ui` - ui
+            * `reaper` - reaper
+            * `rabbitmq` - rabbitmq
+            * `decay` - decay
+            * `usagemeter` - usagemeter
+            * `batch-peer` - batch-peer
+            * `version` - version
+            * `keycloak` - keycloak
+            * `batch-head` - batch-head
+            * `validator` - validator
+            * `query-peer` - query-peer
+            * `postgres` - postgres
+            * `merge-head` - merge-head
+          x-spec-enum-id: 4d89d997bb3ea6b0
+          nullable: true
+      required:
+      - current_replicas
+      - service
+      - storage
+    KafkaSource:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        pool_name:
+          type: string
+          writeOnly: true
+          maxLength: 54
+        k8s_deployment:
+          allOf:
+          - $ref: '#/components/schemas/SourceK8sDeployment'
+          writeOnly: true
+        parent_source:
+          type: string
+          nullable: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        subtype:
+          type: string
+          readOnly: true
+        transform:
+          type: string
+          maxLength: 256
+        table:
+          type: string
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/KafkaSourceSettings'
+      required:
+      - name
+      - settings
+      - subtype
+      - table
+      - type
+      - url
+    KafkaSourceSettings:
+      type: object
+      properties:
+        group_id:
+          type: string
+          readOnly: true
+        bootstrap_servers:
+          type: array
+          items:
+            type: string
+        topics:
+          type: array
+          items:
+            type: string
+        read_timeout:
+          type: string
+          default: 5s
+        max_wait:
+          type: string
+          default: 500ms
+        pool:
+          allOf:
+          - $ref: '#/components/schemas/Pool'
+          readOnly: true
+        offset:
+          enum:
+          - earliest
+          - latest
+          type: string
+          description: |-
+            * `earliest` - earliest
+            * `latest` - latest
+          x-spec-enum-id: 5f099520cacaa3ad
+      required:
+      - bootstrap_servers
+      - group_id
+      - pool
+      - topics
+    KinesisSettingsCheckpointer:
+      type: object
+      properties:
+        name:
+          type: string
+        datastore_project_id:
+          type: string
+      required:
+      - name
+    KinesisSettingsOrganizer:
+      type: object
+      properties:
+        root_path:
+          type: string
+          readOnly: true
+      required:
+      - root_path
+    KinesisSource:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        pool_name:
+          type: string
+          writeOnly: true
+          maxLength: 54
+        k8s_deployment:
+          allOf:
+          - $ref: '#/components/schemas/SourceK8sDeployment'
+          writeOnly: true
+        parent_source:
+          type: string
+          nullable: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        subtype:
+          type: string
+          readOnly: true
+        transform:
+          type: string
+          maxLength: 256
+        table:
+          type: string
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/KinesisSourceSettings'
+      required:
+      - name
+      - settings
+      - subtype
+      - table
+      - type
+      - url
+    KinesisSourceSettings:
+      type: object
+      properties:
+        stream_name:
+          type: string
+        region:
+          type: string
+        organizer:
+          allOf:
+          - $ref: '#/components/schemas/KinesisSettingsOrganizer'
+          readOnly: true
+        checkpointer:
+          $ref: '#/components/schemas/KinesisSettingsCheckpointer'
+        pool:
+          allOf:
+          - $ref: '#/components/schemas/Pool'
+          readOnly: true
+        aws_key:
+          type: string
+          writeOnly: true
+        aws_secret:
+          type: string
+          writeOnly: true
+        aws_creds_key:
+          type: string
+          readOnly: true
+        aws_role_arn:
+          type: string
+        kcl:
+          type: boolean
+        kinesis_credential_id:
+          type: string
+          format: uuid
+        dynamo_credential_id:
+          type: string
+          format: uuid
+      required:
+      - aws_creds_key
+      - checkpointer
+      - organizer
+      - pool
+      - region
+      - stream_name
+    Login:
+      type: object
+      properties:
+        username:
+          type: string
+          format: email
+          description: User's email
+        password:
+          type: string
+          description: User's password
+      required:
+      - password
+      - username
+    MergePoolsOrgSettings:
+      type: object
+      properties:
+        small:
+          type: string
+        medium:
+          type: string
+        large:
+          type: string
+    MergePoolsSettings:
+      type: object
+      properties:
+        small:
+          type: string
+        medium:
+          type: string
+        large:
+          type: string
+    MetaOrg:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        type:
+          type: string
+          readOnly: true
+        cloud:
+          type: string
+          readOnly: true
+        kubernetes:
+          type: boolean
+          readOnly: true
+      required:
+      - cloud
+      - kubernetes
+      - name
+      - type
+    MetaTable:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+      required:
+      - name
+    Org:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        type:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/OrgSettings'
+          default:
+            default_query_options: {}
+        publish_task_id:
+          type: integer
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - publish_task_id
+      - type
+    OrgQueryOptions:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+          nullable: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/OrgSettings'
+          default:
+            default_query_options: {}
+        publish_task_id:
+          type: integer
+          readOnly: true
+      required:
+      - created
+      - description
+      - modified
+      - name
+      - publish_task_id
+      - type
+      - uuid
+    OrgSettings:
+      type: object
+      properties:
+        default_query_options:
+          allOf:
+          - $ref: '#/components/schemas/DefaultOrgQueryOptions'
+          default: {}
+        merge_pools:
+          $ref: '#/components/schemas/MergePoolsOrgSettings'
+    OrgSummary:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        type:
+          type: integer
+          nullable: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          nullable: true
+        publish_task_id:
+          type: integer
+          readOnly: true
+        projects:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProjectSet'
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - projects
+      - publish_task_id
+    PaginatedActivityList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Activity'
+    PaginatedAlterJobList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/AlterJob'
+    PaginatedBatchJobList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BatchJob'
+    PaginatedCatalogList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Catalog'
+    PaginatedOrgList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Org'
+    PaginatedProcrastinateEventList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcrastinateEvent'
+    PaginatedProcrastinateTaskList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcrastinateTask'
+    PasswordReset:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+      required:
+      - email
+    PasswordResetConfirm:
+      type: object
+      properties:
+        password:
+          type: string
+        password_confirm:
+          type: string
+        uuidb64:
+          type: string
+        token:
+          type: string
+      required:
+      - password
+      - password_confirm
+      - token
+      - uuidb64
+    PatchedDictionary:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Dictionary's name value
+          maxLength: 64
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+          description: project's id where the dictionary is created.
+        description:
+          type: string
+          nullable: true
+          description: The description for the dictionary.
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/DictionarySettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+    PatchedFunction:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        sql:
+          type: string
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        publish_task_id:
+          type: integer
+          readOnly: true
+    PatchedHdxStorage:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/HdxStorageSettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+    PatchedKafkaSource:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        pool_name:
+          type: string
+          writeOnly: true
+          maxLength: 54
+        k8s_deployment:
+          allOf:
+          - $ref: '#/components/schemas/SourceK8sDeployment'
+          writeOnly: true
+        parent_source:
+          type: string
+          nullable: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        subtype:
+          type: string
+          readOnly: true
+        transform:
+          type: string
+          maxLength: 256
+        table:
+          type: string
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/KafkaSourceSettings'
+    PatchedKinesisSource:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        pool_name:
+          type: string
+          writeOnly: true
+          maxLength: 54
+        k8s_deployment:
+          allOf:
+          - $ref: '#/components/schemas/SourceK8sDeployment'
+          writeOnly: true
+        parent_source:
+          type: string
+          nullable: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        subtype:
+          type: string
+          readOnly: true
+        transform:
+          type: string
+          maxLength: 256
+        table:
+          type: string
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/KinesisSourceSettings'
+    PatchedOrg:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        type:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/OrgSettings'
+          default: {}
+        publish_task_id:
+          type: integer
+          readOnly: true
+    PatchedOrgQueryOptions:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+          nullable: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/OrgSettings'
+          default: {}
+        publish_task_id:
+          type: integer
+          readOnly: true
+    PatchedProject:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/ProjectSettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+    PatchedProjectQueryOptions:
+      type: object
+      properties:
+        name:
+          type: string
+          readOnly: true
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+          nullable: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/ProjectSettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+    PatchedRole:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/RolePolicy'
+    PatchedServiceAccount:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        audit:
+          type: boolean
+          readOnly: true
+        is_service_account:
+          type: boolean
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+          minLength: 3
+    PatchedSiemSource:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        pool_name:
+          type: string
+          writeOnly: true
+          maxLength: 54
+        k8s_deployment:
+          allOf:
+          - $ref: '#/components/schemas/SourceK8sDeployment'
+          writeOnly: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        subtype:
+          type: string
+          readOnly: true
+        transform:
+          type: string
+          maxLength: 256
+        table:
+          type: string
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/SiemSourceSettings'
+    PatchedSwaggerPool:
+      type: object
+      properties:
+        location:
+          type: string
+          description: Location is legacy. Just return the first one for backwards
+            compatability
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/PoolSettings'
+          default:
+            k8s_deployment:
+              service: null
+        tag:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        name:
+          type: string
+          maxLength: 64
+    PatchedTable:
+      type: object
+      properties:
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/TableSettings'
+          default:
+            rate_limit: null
+            stream:
+              hot_data_max_age_minutes: 60
+              hot_data_max_active_partitions: 12
+              hot_data_max_rows_per_partition: 1048576
+              hot_data_max_minutes_per_partition: 5
+              hot_data_max_open_seconds: 20
+              hot_data_max_idle_seconds: 10
+              cold_data_max_age_days: 3650
+              cold_data_max_active_partitions: 168
+              cold_data_max_rows_per_partition: 1048576
+              cold_data_max_minutes_per_partition: 60
+              cold_data_max_open_seconds: 60
+              cold_data_max_idle_seconds: 30
+              message_queue_max_rows: 500
+            age:
+              max_age_days: 0
+            reaper:
+              max_age_days: 1
+            merge:
+              enabled: true
+            autoingest:
+            - enabled: false
+              source: ''
+              pattern: ''
+              max_rows_per_partition: 12288000
+              max_minutes_per_partition: 60
+              max_active_partitions: 50
+              dry_run: false
+              source_credential_id: null
+              bucket_credential_id: null
+            sort_keys: []
+            shard_key: null
+            max_future_days: 0
+            max_request_bytes: 0
+        publish_task_id:
+          type: integer
+          readOnly: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          nullable: true
+          default: turbine
+          maxLength: 256
+        primary_key:
+          type: string
+          readOnly: true
+    PatchedTableQueryOptions:
+      type: object
+      properties:
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+          nullable: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/TableSettings'
+          default:
+            rate_limit: null
+            stream:
+              hot_data_max_age_minutes: 60
+              hot_data_max_active_partitions: 12
+              hot_data_max_rows_per_partition: 1048576
+              hot_data_max_minutes_per_partition: 5
+              hot_data_max_open_seconds: 20
+              hot_data_max_idle_seconds: 10
+              cold_data_max_age_days: 3650
+              cold_data_max_active_partitions: 168
+              cold_data_max_rows_per_partition: 1048576
+              cold_data_max_minutes_per_partition: 60
+              cold_data_max_open_seconds: 60
+              cold_data_max_idle_seconds: 30
+              message_queue_max_rows: 500
+            age:
+              max_age_days: 0
+            reaper:
+              max_age_days: 1
+            merge:
+              enabled: true
+            autoingest:
+            - enabled: false
+              source: ''
+              pattern: ''
+              max_rows_per_partition: 12288000
+              max_minutes_per_partition: 60
+              max_active_partitions: 50
+              dry_run: false
+              source_credential_id: null
+              bucket_credential_id: null
+            sort_keys: []
+            shard_key: null
+            max_future_days: 0
+            max_request_bytes: 0
+        publish_task_id:
+          type: integer
+          readOnly: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          nullable: true
+          default: turbine
+          maxLength: 256
+        primary_key:
+          type: string
+          readOnly: true
+    PatchedTransformTemplate:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/TransformSettings'
+        type:
+          type: string
+        name:
+          type: string
+          maxLength: 50
+          pattern: ^[-a-zA-Z0-9_]+$
+        description:
+          type: string
+        read_only:
+          type: boolean
+          readOnly: true
+    Pool:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/PoolSettings'
+          default:
+            k8s_deployment:
+              service: null
+        location:
+          type: string
+          description: Location is legacy. Just return the first one for backwards
+            compatability
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        tag:
+          type: string
+          readOnly: true
+        pool_id:
+          type: string
+          format: uuid
+          writeOnly: true
+      required:
+      - created
+      - location
+      - modified
+      - name
+      - tag
+      - type
+    PoolSettings:
+      type: object
+      properties:
+        is_head:
+          type: boolean
+          readOnly: true
+        k8s_deployment:
+          $ref: '#/components/schemas/K8sDeployment'
+      required:
+      - is_head
+      - k8s_deployment
+    ProcrastinateEvent:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        type:
+          enum:
+          - deferred
+          - started
+          - deferred_for_retry
+          - failed
+          - succeeded
+          - cancelled
+          - abort_requested
+          - aborted
+          - scheduled
+          type: string
+          description: |-
+            * `deferred` - deferred
+            * `started` - started
+            * `deferred_for_retry` - deferred_for_retry
+            * `failed` - failed
+            * `succeeded` - succeeded
+            * `cancelled` - cancelled
+            * `abort_requested` - abort_requested
+            * `aborted` - aborted
+            * `scheduled` - scheduled
+          x-spec-enum-id: ce47322d727b7c78
+        job:
+          type: integer
+        at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - id
+      - job
+      - type
+    ProcrastinateTask:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        queue_name:
+          type: string
+          maxLength: 128
+        task_name:
+          type: string
+          maxLength: 128
+        priority:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        lock:
+          type: string
+          nullable: true
+        args: {}
+        status:
+          enum:
+          - todo
+          - doing
+          - succeeded
+          - failed
+          - cancelled
+          - aborting
+          - aborted
+          type: string
+          description: |-
+            * `todo` - todo
+            * `doing` - doing
+            * `succeeded` - succeeded
+            * `failed` - failed
+            * `cancelled` - cancelled
+            * `aborting` - aborting
+            * `aborted` - aborted
+          x-spec-enum-id: 0f31f28290bff67e
+        scheduled_at:
+          type: string
+          format: date-time
+          nullable: true
+        attempts:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        queueing_lock:
+          type: string
+          nullable: true
+      required:
+      - args
+      - attempts
+      - id
+      - priority
+      - queue_name
+      - status
+      - task_name
+    Project:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/ProjectSettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - org
+      - publish_task_id
+      - url
+    ProjectQueryOptions:
+      type: object
+      properties:
+        name:
+          type: string
+          readOnly: true
+        org:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+          nullable: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        url:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/ProjectSettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+      required:
+      - created
+      - description
+      - modified
+      - name
+      - org
+      - publish_task_id
+      - url
+      - uuid
+    ProjectSet:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        tables:
+          type: array
+          items:
+            $ref: '#/components/schemas/TableSet'
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - tables
+    ProjectSettings:
+      type: object
+      properties:
+        default_query_options:
+          allOf:
+          - $ref: '#/components/schemas/DefaultProjectQueryOptions'
+          default: {}
+        blob:
+          nullable: true
+        rate_limit:
+          allOf:
+          - $ref: '#/components/schemas/RateLimitOptions'
+          nullable: true
+    ProjectStats:
+      type: object
+      properties:
+        summary:
+          type: object
+          additionalProperties: {}
+          readOnly: true
+        tables:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          readOnly: true
+      required:
+      - summary
+      - tables
+    PurgeJob:
+      type: object
+      properties:
+        purged_jobs:
+          type: integer
+          readOnly: true
+      required:
+      - purged_jobs
+    RateLimitOptions:
+      type: object
+      properties:
+        limit:
+          type: integer
+          nullable: true
+        burst:
+          type: integer
+          nullable: true
+    Role:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/RolePolicy'
+      required:
+      - id
+      - name
+    RolePolicy:
+      type: object
+      properties:
+        permissions:
+          type: array
+          items:
+            type: string
+        scope_type:
+          type: string
+          title: Python model class name
+        scope_id:
+          type: string
+          format: uuid
+        scope_name:
+          type: string
+          readOnly: true
+      required:
+      - permissions
+      - scope_name
+    ServiceAccount:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        audit:
+          type: boolean
+          readOnly: true
+        is_service_account:
+          type: boolean
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+          minLength: 3
+      required:
+      - audit
+      - is_service_account
+      - name
+      - uuid
+    SiemSettingsAccessDetails:
+      type: object
+      properties:
+        host:
+          type: string
+        entity_id:
+          type: string
+        client_secret:
+          type: string
+          writeOnly: true
+        client_token:
+          type: string
+          writeOnly: true
+        access_token:
+          type: string
+          writeOnly: true
+        client_secret_key:
+          type: string
+          readOnly: true
+        client_token_key:
+          type: string
+          readOnly: true
+        access_token_key:
+          type: string
+          readOnly: true
+        limit:
+          type: integer
+      required:
+      - access_token
+      - access_token_key
+      - client_secret
+      - client_secret_key
+      - client_token
+      - client_token_key
+      - entity_id
+      - host
+    SiemSettingsCheckpointer:
+      type: object
+      properties:
+        name:
+          type: string
+          default: zk
+    SiemSource:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        pool_name:
+          type: string
+          writeOnly: true
+          maxLength: 54
+        k8s_deployment:
+          allOf:
+          - $ref: '#/components/schemas/SourceK8sDeployment'
+          writeOnly: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        subtype:
+          type: string
+          readOnly: true
+        transform:
+          type: string
+          maxLength: 256
+        table:
+          type: string
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/SiemSourceSettings'
+      required:
+      - name
+      - settings
+      - subtype
+      - table
+      - type
+      - url
+    SiemSourceSettings:
+      type: object
+      properties:
+        access_details:
+          $ref: '#/components/schemas/SiemSettingsAccessDetails'
+        checkpointer:
+          allOf:
+          - $ref: '#/components/schemas/SiemSettingsCheckpointer'
+          default:
+            name: zk
+        pool:
+          allOf:
+          - $ref: '#/components/schemas/Pool'
+          readOnly: true
+      required:
+      - access_details
+      - pool
+    SourceK8sDeployment:
+      type: object
+      description: |-
+        When making sources, we don't need the full deployment serializer
+        service will be hard-coded
+      properties:
+        current_replicas:
+          type: string
+          readOnly: true
+        replicas:
+          type: string
+        cpu:
+          type: string
+        memory:
+          type: string
+        storage:
+          type: string
+          readOnly: true
+        scale_profile:
+          type: string
+          readOnly: true
+        service:
+          enum:
+          - query-peer
+          - stream-peer
+          - kafka-peer
+          - akamai-siem-peer
+          - merge-peer
+          - kinesis-peer
+          - kinesis-kcl-peer
+          - intake-head
+          - stream-head
+          type: string
+          description: |-
+            * `query-peer` - query-peer
+            * `stream-peer` - stream-peer
+            * `kafka-peer` - kafka-peer
+            * `akamai-siem-peer` - akamai-siem-peer
+            * `merge-peer` - merge-peer
+            * `kinesis-peer` - kinesis-peer
+            * `kinesis-kcl-peer` - kinesis-kcl-peer
+            * `intake-head` - intake-head
+            * `stream-head` - stream-head
+          x-spec-enum-id: 1fa6aadd2ef8c640
+          readOnly: true
+      required:
+      - current_replicas
+      - scale_profile
+      - service
+      - storage
+    SummarizedQueryOptions:
+      type: object
+      properties:
+        type:
+          type: string
+          readOnly: true
+        uuid:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        query_options:
+          type: string
+          readOnly: true
+      required:
+      - name
+      - query_options
+      - type
+      - uuid
+    SwaggerPool:
+      type: object
+      properties:
+        location:
+          type: string
+          description: Location is legacy. Just return the first one for backwards
+            compatability
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/PoolSettings'
+          default:
+            k8s_deployment:
+              service: null
+        tag:
+          type: string
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        type:
+          type: string
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        name:
+          type: string
+          maxLength: 64
+      required:
+      - created
+      - location
+      - modified
+      - name
+      - tag
+      - type
+    Table:
+      type: object
+      properties:
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/TableSettings'
+          default:
+            default_query_options: {}
+            rate_limit: null
+            stream:
+              token_list: []
+              intake_head_url: https://{myhost}.hydrolix.live/ingest/event
+              hot_data_max_age_minutes: 60
+              hot_data_max_active_partitions: 12
+              hot_data_max_rows_per_partition: 1048576
+              hot_data_max_minutes_per_partition: 5
+              hot_data_max_open_seconds: 20
+              hot_data_max_idle_seconds: 10
+              cold_data_max_age_days: 3650
+              cold_data_max_active_partitions: 168
+              cold_data_max_rows_per_partition: 1048576
+              cold_data_max_minutes_per_partition: 60
+              cold_data_max_open_seconds: 60
+              cold_data_max_idle_seconds: 30
+              message_queue_max_rows: 500
+            age:
+              max_age_days: 0
+            reaper:
+              max_age_days: 1
+            merge:
+              enabled: true
+            autoingest:
+            - enabled: false
+              source: ''
+              source_region: ''
+              pattern: ''
+              max_rows_per_partition: 12288000
+              max_minutes_per_partition: 60
+              max_active_partitions: 50
+              dry_run: false
+              source_credential_id: null
+              bucket_credential_id: null
+            sort_keys: []
+            shard_key: null
+            max_future_days: 0
+            max_request_bytes: 0
+        publish_task_id:
+          type: integer
+          readOnly: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          nullable: true
+          default: turbine
+          maxLength: 256
+        primary_key:
+          type: string
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - primary_key
+      - project
+      - publish_task_id
+      - url
+    TableAgeSettings:
+      type: object
+      properties:
+        max_age_days:
+          type: integer
+          default: 0
+    TableAutoingestSettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: false
+        source:
+          type: string
+          default: ''
+        source_region:
+          type: string
+          default: ''
+        pattern:
+          type: string
+          default: ''
+        max_rows_per_partition:
+          type: integer
+          default: 12288000
+        max_minutes_per_partition:
+          type: integer
+          default: 60
+        max_active_partitions:
+          type: integer
+          default: 50
+        dry_run:
+          type: boolean
+          default: false
+        name:
+          type: string
+        transform:
+          type: string
+        source_credential_id:
+          type: string
+          format: uuid
+          nullable: true
+        bucket_credential_id:
+          type: string
+          format: uuid
+          nullable: true
+    TableMergeSettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        sql:
+          type: string
+        memory_coefficient:
+          type: string
+          format: decimal
+        pools:
+          $ref: '#/components/schemas/MergePoolsSettings'
+    TableQueryOptions:
+      type: object
+      properties:
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+          nullable: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          allOf:
+          - $ref: '#/components/schemas/TableSettings'
+          default:
+            default_query_options: {}
+            rate_limit: null
+            stream:
+              token_list: []
+              intake_head_url: https://{myhost}.hydrolix.live/ingest/event
+              hot_data_max_age_minutes: 60
+              hot_data_max_active_partitions: 12
+              hot_data_max_rows_per_partition: 1048576
+              hot_data_max_minutes_per_partition: 5
+              hot_data_max_open_seconds: 20
+              hot_data_max_idle_seconds: 10
+              cold_data_max_age_days: 3650
+              cold_data_max_active_partitions: 168
+              cold_data_max_rows_per_partition: 1048576
+              cold_data_max_minutes_per_partition: 60
+              cold_data_max_open_seconds: 60
+              cold_data_max_idle_seconds: 30
+              message_queue_max_rows: 500
+            age:
+              max_age_days: 0
+            reaper:
+              max_age_days: 1
+            merge:
+              enabled: true
+            autoingest:
+            - enabled: false
+              source: ''
+              source_region: ''
+              pattern: ''
+              max_rows_per_partition: 12288000
+              max_minutes_per_partition: 60
+              max_active_partitions: 50
+              dry_run: false
+              source_credential_id: null
+              bucket_credential_id: null
+            sort_keys: []
+            shard_key: null
+            max_future_days: 0
+            max_request_bytes: 0
+        publish_task_id:
+          type: integer
+          readOnly: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          nullable: true
+          default: turbine
+          maxLength: 256
+        primary_key:
+          type: string
+          readOnly: true
+      required:
+      - created
+      - description
+      - modified
+      - name
+      - primary_key
+      - project
+      - publish_task_id
+      - url
+      - uuid
+    TableReaperSettings:
+      type: object
+      properties:
+        max_age_days:
+          type: integer
+          default: 1
+    TableSet:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+    TableSettings:
+      type: object
+      properties:
+        default_query_options:
+          allOf:
+          - $ref: '#/components/schemas/DefaultTableQueryOptions'
+          default: {}
+        rate_limit:
+          allOf:
+          - $ref: '#/components/schemas/RateLimitOptions'
+          nullable: true
+        summary:
+          $ref: '#/components/schemas/TableSummarySettings'
+        stream:
+          allOf:
+          - $ref: '#/components/schemas/TableStreamSettings'
+          default:
+            token_list: []
+            intake_head_url: https://{myhost}.hydrolix.live/ingest/event
+            hot_data_max_age_minutes: 60
+            hot_data_max_active_partitions: 12
+            hot_data_max_rows_per_partition: 1048576
+            hot_data_max_minutes_per_partition: 5
+            hot_data_max_open_seconds: 20
+            hot_data_max_idle_seconds: 10
+            cold_data_max_age_days: 3650
+            cold_data_max_active_partitions: 168
+            cold_data_max_rows_per_partition: 1048576
+            cold_data_max_minutes_per_partition: 60
+            cold_data_max_open_seconds: 60
+            cold_data_max_idle_seconds: 30
+            message_queue_max_rows: 500
+        age:
+          allOf:
+          - $ref: '#/components/schemas/TableAgeSettings'
+          default:
+            max_age_days: 0
+        reaper:
+          allOf:
+          - $ref: '#/components/schemas/TableReaperSettings'
+          default:
+            max_age_days: 1
+        merge:
+          allOf:
+          - $ref: '#/components/schemas/TableMergeSettings'
+          default:
+            enabled: true
+        autoingest:
+          type: array
+          items:
+            $ref: '#/components/schemas/TableAutoingestSettings'
+          default:
+          - enabled: false
+            source: ''
+            source_region: ''
+            pattern: ''
+            max_rows_per_partition: 12288000
+            max_minutes_per_partition: 60
+            max_active_partitions: 50
+            dry_run: false
+            source_credential_id: null
+            bucket_credential_id: null
+        sort_keys:
+          type: array
+          items:
+            type: string
+          nullable: true
+          default: []
+        shard_key:
+          type: string
+          nullable: true
+        max_future_days:
+          type: integer
+          default: 0
+        max_request_bytes:
+          type: integer
+          default: 0
+        storage_map:
+          $ref: '#/components/schemas/TableStorageMapSettings'
+    TableStats:
+      type: object
+      properties:
+        name:
+          type: string
+          readOnly: true
+        total_partitions:
+          type: integer
+          readOnly: true
+        total_rows:
+          type: integer
+          readOnly: true
+        total_data_size:
+          type: integer
+          readOnly: true
+        total_storage_size:
+          type: integer
+          readOnly: true
+        total_raw_data_size:
+          type: integer
+          readOnly: true
+      required:
+      - name
+      - total_data_size
+      - total_partitions
+      - total_raw_data_size
+      - total_rows
+      - total_storage_size
+    TableStorageMapSettings:
+      type: object
+      properties:
+        default_storage_id:
+          type: string
+          format: uuid
+        column_name:
+          type: string
+          nullable: true
+        column_value_mapping:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              nullable: true
+        spread_list:
+          type: array
+          items:
+            type: string
+            format: uuid
+    TableStreamSettings:
+      type: object
+      properties:
+        token_auth_enabled:
+          type: boolean
+        token_list:
+          type: array
+          items:
+            type: string
+          nullable: true
+          default: []
+        intake_head_url:
+          type: string
+          readOnly: true
+          default: https://{myhost}.hydrolix.live/ingest/event
+        hot_data_max_age_minutes:
+          type: integer
+          default: 60
+        hot_data_max_active_partitions:
+          type: integer
+          default: 12
+        hot_data_max_rows_per_partition:
+          type: integer
+          default: 1048576
+        hot_data_max_minutes_per_partition:
+          type: integer
+          default: 5
+        hot_data_max_open_seconds:
+          type: integer
+          default: 20
+        hot_data_max_idle_seconds:
+          type: integer
+          default: 10
+        cold_data_max_age_days:
+          type: integer
+          default: 3650
+        cold_data_max_active_partitions:
+          type: integer
+          default: 168
+        cold_data_max_rows_per_partition:
+          type: integer
+          default: 1048576
+        cold_data_max_minutes_per_partition:
+          type: integer
+          default: 60
+        cold_data_max_open_seconds:
+          type: integer
+          default: 60
+        cold_data_max_idle_seconds:
+          type: integer
+          default: 30
+        message_queue_max_rows:
+          type: integer
+          default: 500
+        sample_rate:
+          type: number
+          format: double
+      required:
+      - intake_head_url
+    TableSummarySettings:
+      type: object
+      properties:
+        parents:
+          type: array
+          items:
+            type: string
+            format: uuid
+          readOnly: true
+        sql:
+          type: string
+        summary_sql:
+          type: string
+        enabled:
+          type: boolean
+          default: true
+        max_open_seconds:
+          type: integer
+        max_idle_seconds:
+          type: integer
+        max_partitions:
+          type: integer
+        max_width:
+          type: integer
+          maximum: 9999
+          minimum: 0
+      required:
+      - parents
+      - sql
+    Transform:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/TransformSettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+        url:
+          type: string
+          readOnly: true
+        type:
+          type: string
+          maxLength: 256
+        table:
+          type: string
+          format: uuid
+          readOnly: true
+        template:
+          type: string
+          writeOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - publish_task_id
+      - table
+      - url
+    TransformDataType:
+      type: object
+      properties:
+        type:
+          enum:
+          - uint8
+          - uint32
+          - json
+          - array
+          - int32
+          - string
+          - int8
+          - uint64
+          - map
+          - bool
+          - datetime
+          - double
+          - epoch
+          - boolean
+          - int64
+          type: string
+          description: |-
+            * `uint8` - uint8
+            * `uint32` - uint32
+            * `json` - json
+            * `array` - array
+            * `int32` - int32
+            * `string` - string
+            * `int8` - int8
+            * `uint64` - uint64
+            * `map` - map
+            * `bool` - bool
+            * `datetime` - datetime
+            * `double` - double
+            * `epoch` - epoch
+            * `boolean` - boolean
+            * `int64` - int64
+          x-spec-enum-id: acbd6ac569c63e6b
+        index:
+          type: boolean
+        index_options:
+          $ref: '#/components/schemas/DataTypeIndexOptions'
+        denullify:
+          type: boolean
+        virtual:
+          type: boolean
+        primary:
+          type: boolean
+        catch_all:
+          type: boolean
+        catch_rejects:
+          type: boolean
+        sql_expression:
+          type: string
+        null_values:
+          type: array
+          items:
+            type: string
+        ignore:
+          type: boolean
+        limits: {}
+        format:
+          type: string
+          nullable: true
+        resolution:
+          enum:
+          - milliseconds
+          - millisecond
+          - millis
+          - milli
+          - ms
+          - seconds
+          - second
+          - secs
+          - sec
+          - s
+          - null
+          type: string
+          description: |-
+            * `milliseconds` - milliseconds
+            * `millisecond` - millisecond
+            * `millis` - millis
+            * `milli` - milli
+            * `ms` - ms
+            * `seconds` - seconds
+            * `second` - second
+            * `secs` - secs
+            * `sec` - sec
+            * `s` - s
+          x-spec-enum-id: 2235386374b0a96f
+          nullable: true
+        default:
+          nullable: true
+        script:
+          type: string
+          nullable: true
+        elements:
+          type: array
+          items:
+            $ref: '#/components/schemas/ElementsDataType'
+        source:
+          allOf:
+          - $ref: '#/components/schemas/DataTypeSource'
+          nullable: true
+        suppress:
+          type: boolean
+          default: false
+      required:
+      - type
+    TransformGenerate:
+      type: object
+      properties:
+        sample:
+          type: string
+          writeOnly: true
+        file:
+          type: string
+          format: uri
+          writeOnly: true
+        format:
+          type: string
+          writeOnly: true
+          maxLength: 256
+        type:
+          enum:
+          - file
+          - text
+          type: string
+          description: |-
+            * `file` - file
+            * `text` - text
+          x-spec-enum-id: 2173a3aa7f9af6b5
+          writeOnly: true
+        delimiter:
+          type: string
+          writeOnly: true
+          default: ','
+          maxLength: 1
+        output_columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransformOutputColumns'
+          readOnly: true
+      required:
+      - format
+      - output_columns
+      - type
+    TransformOutputColumns:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        datatype:
+          $ref: '#/components/schemas/TransformDataType'
+      required:
+      - datatype
+      - name
+    TransformSettings:
+      type: object
+      properties:
+        is_default:
+          type: boolean
+          default: false
+        rate_limit:
+          allOf:
+          - $ref: '#/components/schemas/RateLimitOptions'
+          nullable: true
+        sql_transform:
+          type: string
+          nullable: true
+        null_values:
+          type: array
+          items:
+            type: string
+        sample_data:
+          nullable: true
+        shadow_table:
+          allOf:
+          - $ref: '#/components/schemas/TransformShadowTableTarget'
+          nullable: true
+        output_columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransformOutputColumns'
+        compression:
+          enum:
+          - gzip
+          - x-gzip
+          - gz
+          - zlib
+          - zip
+          - deflate
+          - flate
+          - bzip2
+          - x-bzip2
+          - bz2
+          - identity
+          - none
+          - ''
+          type: string
+          description: |-
+            * `gzip` - gzip
+            * `x-gzip` - x-gzip
+            * `gz` - gz
+            * `zlib` - zlib
+            * `zip` - zip
+            * `deflate` - deflate
+            * `flate` - flate
+            * `bzip2` - bzip2
+            * `x-bzip2` - x-bzip2
+            * `bz2` - bz2
+            * `identity` - identity
+            * `none` - none
+          x-spec-enum-id: 732252827e6c967e
+          default: none
+        wurfl:
+          allOf:
+          - $ref: '#/components/schemas/TransformWurflSettings'
+          nullable: true
+        format_details: {}
+      required:
+      - format_details
+      - output_columns
+    TransformShadowTableTarget:
+      type: object
+      properties:
+        table_id:
+          type: string
+          format: uuid
+        transform_id:
+          type: string
+          format: uuid
+        rate:
+          type: number
+          format: double
+          maximum: 0.05
+          minimum: 0.0
+          default: 0.0
+      required:
+      - table_id
+      - transform_id
+    TransformTemplate:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/TransformSettings'
+        type:
+          type: string
+        name:
+          type: string
+          maxLength: 50
+          pattern: ^[-a-zA-Z0-9_]+$
+        description:
+          type: string
+        read_only:
+          type: boolean
+          readOnly: true
+      required:
+      - id
+      - name
+      - read_only
+      - settings
+      - type
+    TransformWurflSettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: false
+        bootstrap_uri:
+          type: string
+          nullable: true
+        update_url:
+          type: string
+          nullable: true
+        header_mapping:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+      - header_mapping
+    TruncateTable:
+      type: object
+      properties:
+        deactivated_partitions:
+          type: integer
+          readOnly: true
+      required:
+      - deactivated_partitions
+    User:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        email:
+          type: string
+          format: email
+          readOnly: true
+        orgs:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetaOrg'
+          readOnly: true
+        is_superuser:
+          type: boolean
+          title: Superuser status
+          description: Designates that this user has all permissions without explicitly
+            assigning them.
+        roles:
+          type: array
+          items:
+            type: string
+        audit:
+          type: boolean
+          readOnly: true
+        emailVerified:
+          type: boolean
+          default: false
+        is_service_account:
+          type: boolean
+          readOnly: true
+      required:
+      - audit
+      - email
+      - is_service_account
+      - orgs
+      - roles
+      - uuid
+    UserSimple:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        username:
+          type: string
+          readOnly: true
+      required:
+      - username
+      - uuid
+    View:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          nullable: true
+          maxLength: 256
+        uuid:
+          type: string
+          format: uuid
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+        settings:
+          $ref: '#/components/schemas/ViewSettings'
+        publish_task_id:
+          type: integer
+          readOnly: true
+        url:
+          type: string
+          readOnly: true
+        table:
+          type: string
+          format: uuid
+          readOnly: true
+      required:
+      - created
+      - modified
+      - name
+      - publish_task_id
+      - settings
+      - table
+      - url
+    ViewOutputColumns:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          enum:
+          - datetime
+          - datetime64
+          - double
+          - uint8
+          - uint32
+          - uint64
+          - int8
+          - int32
+          - int64
+          - string
+          - array
+          - map
+          - json
+          - epoch
+          - bool
+          - boolean
+          type: string
+          description: |-
+            * `datetime` - datetime
+            * `datetime64` - datetime64
+            * `double` - double
+            * `uint8` - uint8
+            * `uint32` - uint32
+            * `uint64` - uint64
+            * `int8` - int8
+            * `int32` - int32
+            * `int64` - int64
+            * `string` - string
+            * `array` - array
+            * `map` - map
+            * `json` - json
+            * `epoch` - epoch
+            * `bool` - bool
+            * `boolean` - boolean
+          x-spec-enum-id: f0ab41aa02fd9259
+        treatment:
+          enum:
+          - primary
+          - metric
+          - tag
+          type: string
+          description: |-
+            * `primary` - primary
+            * `metric` - metric
+            * `tag` - tag
+          x-spec-enum-id: bc6fd661c317dae4
+        datatype:
+          $ref: '#/components/schemas/DataType'
+        aliases:
+          type: array
+          items:
+            type: string
+          readOnly: true
+        current_name:
+          type: string
+          readOnly: true
+      required:
+      - aliases
+      - current_name
+      - name
+    ViewSettings:
+      type: object
+      properties:
+        is_default:
+          type: boolean
+          default: false
+        output_columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/ViewOutputColumns'
+      required:
+      - output_columns
+  securitySchemes:
+    Authentication:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+servers:
+- url: https://{myhost}.hydrolix.live

--- a/zuplo/readme.md
+++ b/zuplo/readme.md
@@ -1,0 +1,26 @@
+# Project Title
+
+Use the configuration files in this repo to accompish either of the following:
+* Generate an API gateway in Zuplo for a Hydrolix cluster
+* Export Zuplo logs and generate Grafana dashboards to view the exported Zuplo data
+
+## Getting Started
+
+### Dependencies
+
+* [A running Hydrolix cluster](https://docs.hydrolix.io/docs/welcome)
+* [A Zuplo account](https://zuplo.com/docs/articles/what-is-zuplo)
+* [Hydrolix / Akamai TrafficPeak Plugin](https://zuplo.com/docs/articles/plugin-hydrolix-traffic-peak), required for Zuplo log export to Hydrolix
+
+## Installation
+
+See the Hydrolix [integration with Zuplo documentation](https://docs.hydrolix.io/docs/zuplo-integration) for installation details.
+
+Note that while the [Grafana dashboard JSON files](https://github.com/hydrolix/hydrolix_examples/tree/master/zuplo/grafana-dashboards) and [Hydrolix transform](https://github.com/hydrolix/hydrolix_examples/tree/master/zuplo/transforms) can be used as-is, the [OpenAPI schema](https://github.com/hydrolix/hydrolix_examples/tree/master/zuplo/openapi-schemas) must be edited before use to replace the following line:
+
+```json
+servers:
+- url: https://{myhost}.hydrolix.live
+```
+
+with the URL of your running Hydrolix cluster. For more details, see the [Zuplo integration documentation](https://docs.hydrolix.io/docs/zuplo-integration).

--- a/zuplo/transforms/zuplo-default-logs.json
+++ b/zuplo/transforms/zuplo-default-logs.json
@@ -1,0 +1,496 @@
+[
+  {
+    "name": "deploymentName",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "primary": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "timestamp",
+    "datatype": {
+      "type": "datetime",
+      "index": false,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": true,
+      "ignore": false,
+      "format": "2006-01-02T15:04:05.000Z",
+      "resolution": "ms",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "requestId",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "primary": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "routePath",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "primary": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "url",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "primary": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "statusCode",
+    "datatype": {
+      "type": "int32",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "durationMs",
+    "datatype": {
+      "type": "int32",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "method",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "primary": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "instanceId",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "primary": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "zuploUserAgent",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "primary": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "projectName",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "accountName",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "userSub",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "colo",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "city",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "country",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "continent",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "latitude",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "longitude",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "postalCode",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "metroCode",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "region",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "regionCode",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "timezone",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "asn",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "asOrganization",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "systemRouteName",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "clientIP",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  },
+  {
+    "name": "logSourceVersion",
+    "datatype": {
+      "type": "string",
+      "index": true,
+      "index_options": {
+        "fulltext": false
+      },
+      "primary": false,
+      "ignore": false,
+      "format": null,
+      "resolution": "seconds",
+      "default": null,
+      "script": null,
+      "source": null,
+      "suppress": false
+    }
+  }
+]


### PR DESCRIPTION
The Hydrolix transform is compatible with default Zuplo log data that can be exported using the [Hydrolix / Trafficpeak export plugin](https://zuplo.com/docs/articles/plugin-hydrolix-traffic-peak). 

Grafana dashboards can be built using the `[grafana-dashboards` json files which match the default Zuplo log data.

The OpenAPI schema is a v5.1.2 Hydrolix cluster Config API schema used to generate a Zuplo gateway. 