### PR TITLE
DOC-1796: bump go.opentelemetry.io/otel to v1.41.0 (CVE-2026-29181)

### DIFF
--- a/exporters/http_to_pubsub/go.mod
+++ b/exporters/http_to_pubsub/go.mod
@@ -23,9 +23,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel v1.41.0 // indirect
+	go.opentelemetry.io/otel/metric v1.41.0 // indirect
+	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect


### PR DESCRIPTION
## Summary

- Bumps `go.opentelemetry.io/otel`, `go.opentelemetry.io/otel/metric`, and `go.opentelemetry.io/otel/trace` from v1.39.0 to v1.41.0 in [`exporters/http_to_pubsub/go.mod`](https://github.com/hydrolix/hydrolix_examples/blob/main/exporters/http_to_pubsub/go.mod).
- Resolves Dependabot alert [#12](https://github.com/hydrolix/hydrolix_examples/security/dependabot/12) — multi-value `baggage:` header amplification → remote DoS via excessive allocations.

## Sources

- GHSA: https://github.com/advisories/GHSA-mh2q-q3fh-2475
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-29181
- Patched release: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.41.0
- Jira: https://hydrolix.atlassian.net/browse/DOC-1796

## Test plan

- [x] `go build ./...` passes in `exporters/http_to_pubsub/`.
- [ ] Dependabot alert auto-closes on merge.