### PR TITLE
Add user-agent regexp dictionary example

### DIFF
--- a/dictionaries/user_agent_regex/readme.md
+++ b/dictionaries/user_agent_regex/readme.md
@@ -1,6 +1,6 @@
 # User-Agent Regexp Dictionary
 
-A [regexp tree dictionary](https://docs.hydrolix.io/docs/regexp-tree-dictionaries) that categorizes user-agent strings during ingest. It groups high-cardinality user-agent values into a small set of categories such as search engine crawlers, AI crawlers, and desktop browsers, so you can index, group by, and filter on the category instead of the raw string.
+A [regexp tree dictionary](https://docs.hydrolix.io/docs/regexp-tree-dictionaries) that categorizes `User-~gent` strings during ingest. It groups high-cardinality user agent values into a small set of categories such as search engine crawlers, AI crawlers, and desktop browsers, so you can index, group by, and filter on the category instead of the raw string.
 
 The dictionary file is [`user_agent_regex_dict.yaml`](user_agent_regex_dict.yaml).
 
@@ -17,7 +17,7 @@ Each pattern node sets these attributes:
 
 ## Use the dictionary
 
-Create a dictionary from the YAML file with the `regexp_tree` layout and `regexp` primary key. Define the schema with these attributes:
+Create a dictionary from the YAML file with the `regexp_tree` layout and `regexp` primary key. Define the `output_columns` with these attributes:
 
 ```json
 [
@@ -28,7 +28,7 @@ Create a dictionary from the YAML file with the `regexp_tree` layout and `regexp
 ]
 ```
 
-To categorize the user agent at ingest, add a `dictGet` lookup to the table's SQL transform that reads the user-agent column:
+To categorize the user agent at ingest, add a `dictGet` lookup to the table's SQL transform that reads the user agent column:
 
 ```sql
 dictGet('myproject_user_agent_regex', 'ua_category', agent) AS user_agent_category

--- a/dictionaries/user_agent_regex/readme.md
+++ b/dictionaries/user_agent_regex/readme.md
@@ -1,0 +1,41 @@
+# User-Agent Regexp Dictionary
+
+A [regexp tree dictionary](https://docs.hydrolix.io/docs/regexp-tree-dictionaries) that categorizes user-agent strings during ingest. It groups high-cardinality user-agent values into a small set of categories such as search engine crawlers, AI crawlers, and desktop browsers, so you can index, group by, and filter on the category instead of the raw string.
+
+The dictionary file is [`user_agent_regex_dict.yaml`](user_agent_regex_dict.yaml).
+
+## Attributes
+
+Each pattern node sets these attributes:
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `regexp` | string | The pattern matched against the user-agent string. This is the dictionary primary key. |
+| `ua_category` | string | The category, such as `Search Engine Crawler`, `AI LLM Crawler`, or `Desktop Browser`. |
+| `is_bot` | uint8 | `1` for automated traffic, `0` for human traffic. |
+| `ai_category` | string | The AI vendor for AI crawler categories, such as `OpenAI`, `Anthropic`, or `Google AI`. |
+
+## Use the dictionary
+
+Create a dictionary from the YAML file with the `regexp_tree` layout and `regexp` primary key. Define the schema with these attributes:
+
+```json
+[
+  { "name": "regexp",      "datatype": { "type": "string", "denullify": true } },
+  { "name": "ua_category", "datatype": { "type": "string", "denullify": true } },
+  { "name": "is_bot",      "datatype": { "type": "uint8",  "denullify": true } },
+  { "name": "ai_category", "datatype": { "type": "string", "denullify": true } }
+]
+```
+
+To categorize the user agent at ingest, add a `dictGet` lookup to the table's SQL transform that reads the user-agent column:
+
+```sql
+dictGet('myproject_user_agent_regex', 'ua_category', agent) AS user_agent_category
+```
+
+For the full walkthrough, see the [Regexp Tree Dictionaries](https://docs.hydrolix.io/docs/regexp-tree-dictionaries) documentation.
+
+## Sources
+
+The category values were seeded from [useragents.me](https://www.useragents.me/) and extended with bot and crawler signatures.

--- a/dictionaries/user_agent_regex/user_agent_regex_dict.yaml
+++ b/dictionaries/user_agent_regex/user_agent_regex_dict.yaml
@@ -1,0 +1,121 @@
+- regexp: '(?i).*Googlebot.*|(?i).*Google-InspectionTool.*|(?i).*Mediapartners-Google.*|(?i).*AdsBot-Google.*|(?i).*APIs-Google.*|(?i).*Storebot-Google.*|(?i).*bingbot.*|(?i).*bingPreview.*|(?i).*msnbot.*|(?i).*AdIdxBot.*|(?i).*slurp.*|(?i).*Baiduspider.*|(?i).*YandexBot.*|(?i).*YandexImages.*|(?i).*YandexAccessibilityBot.*|(?i).*duckduckGo-Favicons-Bot.*|(?i).*duckduckbot.*|(?i).*Applebot.*|(?i).*gogoduck.*'
+  ua_category: 'Search Engine Crawler'
+  is_bot: 1
+
+- regexp: '(?i).*gptbot.*|(?i).*chatgpt-user.*|(?i).*oai-searchbot.*|(?i).*ChatGPT-Browser.*|(?i).*ChatGPT Agent.*'
+  ua_category: 'AI LLM Crawler'
+  ai_category: 'OpenAI'
+  is_bot: 1
+
+- regexp: '(?i).*ClaudeBot.*|(?i).*Claude-Web.*|(?i).*anthropic-ai.*|(?i).*Anthropic-Claude.*|(?i).*Claude-SearchBot.*|(?i).*Claude-User.*'
+  ua_category: 'AI LLM Crawler'
+  ai_category: 'Anthropic'
+  is_bot: 1
+
+- regexp: '(?i).*perplexitybot.*|(?i).*perplexity-user.*|(?i).*Perplexity Stealth.*'
+  ua_category: 'AI LLM Crawler'
+  ai_category: 'Perplexity'
+  is_bot: 1
+
+- regexp: '(?i).*web-bot-auth protocol.*|(?i).*agent.bot.goog.*|(?i).*web-bot-auth.*|(?i).*google-agent.*|(?i).*google-extended.*|(?i).*google-cloudvertexbot.*|(?i).*cloudvertexbot.*|(?i).*gemini-ai.*|(?i).*deep-research.*|(?i).*bard-ai.*'
+  ua_category: 'AI LLM Crawler'
+  ai_category: 'Google AI'
+  is_bot: 1
+
+- regexp: '(?i).*facebookexternalhit.*|(?i).*facebookbot.*|(?i).*meta-externalagent.*|(?i).*meta-externalfetcher.*'
+  ua_category: 'AI LLM Crawler'
+  ai_category: 'Meta AI'
+  is_bot: 1
+
+- regexp: '(?i).*cohere-ai.*|(?i).*cohere-command.*|(?i).*cohere-training-data-crawler.*|(?i).*bytespider.*|(?i).*Amazonbot.*|(?i).*MistralAI.*|(?i).*xAI-Bot.*|(?i).*DeepseekBot.*|(?i).*HuggingFace-Bot.*|(?i).*YouBot.*|(?i).*AI2Bot.*|(?i).*Character-AI.*|(?i).*Groq-Bot.*|(?i).*Together-Bot.*|(?i).*Replicate-Bot.*|(?i).*Andibot.*'
+  ua_category: 'AI LLM Crawler'
+  ai_category: 'Others'
+  is_bot: 1
+
+- regexp: '(?i).*CCBot.*|(?i).*ia_archiver.*|(?i).*archive.org_bot.*'
+  ua_category: 'Common Crawler'
+  is_bot: 1
+
+- regexp: '(?i).*AhrefsBot.*|(?i).*SemrushBot.*|(?i).*dotbot.*|(?i).*rogerbot.*|(?i).*screaming frog seo spider.*|(?i).*mj12bot.*|(?i).*deepcrawl.*|(?i).*oncrawl.*|(?i).*botify.*'
+  ua_category: 'SEO Site Monitoring Tool'
+  is_bot: 1
+
+- regexp: '(?i).*linkedinbot.*|(?i).*twitterbot.*|(?i).*pinterest.*|(?i).*instagram.*|(?i).*telegrambot.*|(?i).*whatsapp.*'
+  ua_category: 'Social Media Crawler'
+  is_bot: 1
+
+- regexp: '(?i).*pingdom.*|(?i).*uptimerobot.*|(?i).*statuscake.*|(?i).*gtmetrix.*|(?i).*catchpoint.*|(?i).*new\s*relic.*|(?i).*dynatrace.*|(?i).*appdynamics.*|(?i).*datadog.*|(?i).*uptimerobot.*|(?i).*pingdom.*|(?i).*site24x7.*|(?i).*uptrends.*|(?i).*statuscake.*|(?i).*touchstream.*|(?i).*proximic.*|(?i).*cfnetwork.*'
+  ua_category: 'Monitoring Uptime Services'
+  is_bot: 1
+
+- regexp: '(?i).*diffbot.*|(?i).*omgili.*|(?i).*webzio-extended.*|(?i).*dataforseobot.*|(?i).*scoutjet.*|(?i).*parsehub.*'
+  ua_category: 'Data Collection Scraping Services'
+  is_bot: 1
+
+- regexp: '(?i).*cloudflare-alwaysonline.*|(?i).*netcraftsurveyagent.*|(?i).*censysinspect.*|(?i).*shodan.*'
+  ua_category: 'Security Analysis'
+  is_bot: 1
+
+- regexp: '(?i).*shopify-captain-hook.*|(?i).*pricerunner-bot.*'
+  ua_category: 'ECommerce Price Monitoring'
+  is_bot: 1
+
+- regexp: '(?i).*flipboard.*|(?i).*feedly.*|(?i).*applenewsbot.*'
+  ua_category: 'News Content Aggregators'
+  is_bot: 1
+
+- regexp: '(?i).*petalbot.*|(?i).*sogou web spider.*|(?i).*360spider.*|(?i).*pangubot.*|(?i).*timpibot.*|(?i).*kangaroo bot.*|(?i).*imagesiftbot.*|(?i).*duckassistbot.*|(?i).*runpod-bot.*|(?i).*firecrawlagent.*|(?i).*brightbot.*|(?i).*cotoyogi.*|(?i).*crawlspace.*|(?i).*devin.*|(?i).*iboubot.*|(?i).*bigsur\.ai.*|(?i).*bedrockbot.*'
+  ua_category: 'Specialized Crawlers'
+  is_bot: 1
+
+- regexp: '(?i).*google-videoads-stitching.*'
+  ua_category: 'Video Crawler'
+  is_bot: 1
+
+- regexp: '(?i).*headless.*|(?i).*phantomjs.*|(?i).*puppeteer.*|(?i).*selenium.*|(?i).*htmlunit.*|(?i).*casperjs.*|(?i).*slimerjs.*'
+  ua_category: 'Headless Browser'
+  is_bot: 1
+
+- regexp: '(?i).*curl.*|(?i).*wget.*|(?i).*python-requests.*|(?i).*httpie.*|(?i).*okhttp.*|(?i).*libcurl.*|(?i).*postmanruntime.*|(?i).*go-http-client.*'
+  ua_category: 'Synthetic Browser'
+  is_bot: 0
+
+- regexp: '(?i).*lavf.*|(?i).*kodi.*|(?i).*ffmpeg.*|(?i).*exoplayer.*|(?i).*openload.*|(?i).*libvlc.*'
+  ua_category: 'Video Player'
+  is_bot: 0
+
+- regexp: '(?i).*roku.*'
+  ua_category: 'Roku'
+  is_bot: 0
+
+- regexp: '(?i).*iphone.*|(?i).*ipod touch.*|(?i).*ipod.*'
+  ua_category: 'Mobile iPhone'
+  is_bot: 0
+
+- regexp: '(?i).*ipad.*'
+  ua_category: 'Tablet iOS'
+  is_bot: 0
+
+- regexp: '(?i).*mfi_airplay_device.*'
+  ua_category: 'Airplay Apple'
+  is_bot: 0
+
+- regexp: '(?i).*android.*mobile.*'
+  ua_category: 'Mobile Android'
+  is_bot: 0
+
+- regexp: '(?i).*android.*'
+  ua_category: 'Tablet Android'
+  is_bot: 0
+
+- regexp: '(?i).*smart-tv.*|(?i).*hbbtv.*|(?i).*appletv.*|(?i).*apple tv.*|(?i).*fetchtv.*|(?i).*smartcast.*|(?i).*firetv.*'
+  ua_category: 'Settop Box'
+  is_bot: 0
+
+- regexp: '(?i).*playstation.*|(?i).*xbox.*|(?i).*nintendo.*|(?i).*apple vision.*'
+  ua_category: 'Gaming Console'
+  is_bot: 0
+
+- regexp: '(?i).*windows.*|(?i).*macintosh.*|(?i).*linux.*|(?i).*x11.*|(?i).*fuchsia.*'
+  ua_category: 'Desktop Browser'
+  is_bot: 0

--- a/readme.md
+++ b/readme.md
@@ -11,5 +11,6 @@ View the README.md file in each directory for more information.
   * Note that more transforms can be found in the official [Hydrolix Transform Repository](https://github.com/hydrolix/transforms))
 * Cribl: [Sample configuration](https://github.com/hydrolix/hydrolix_examples/tree/main/cribl) to export data from Cribl into Hydrolix
 * Cloudflare: [Sample transform](https://github.com/hydrolix/hydrolix_examples/tree/main/cloudflare) to structure data exported from Cloudflare into Hydrolix
+* Dictionaries: A [user-agent regexp dictionary](https://github.com/hydrolix/hydrolix_examples/tree/main/dictionaries/user_agent_regex) that categorizes user-agent strings at ingest
 * Miscellaneous
   * A [Postgres v11 -> v12 upgrade script](miscellaneous/postgres-upgrade-job.yaml) for customers using the internal Postgres pod

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,6 @@ View the README.md file in each directory for more information.
   * Note that more transforms can be found in the official [Hydrolix Transform Repository](https://github.com/hydrolix/transforms))
 * Cribl: [Sample configuration](https://github.com/hydrolix/hydrolix_examples/tree/main/cribl) to export data from Cribl into Hydrolix
 * Cloudflare: [Sample transform](https://github.com/hydrolix/hydrolix_examples/tree/main/cloudflare) to structure data exported from Cloudflare into Hydrolix
-* Dictionaries: A [user-agent regexp dictionary](https://github.com/hydrolix/hydrolix_examples/tree/main/dictionaries/user_agent_regex) that categorizes user-agent strings at ingest
+* Dictionaries: A [user-agent regexp dictionary](https://github.com/hydrolix/hydrolix_examples/tree/main/dictionaries/user_agent_regex) that categorizes `User-Agent` strings at ingest
 * Miscellaneous
   * A [Postgres v11 -> v12 upgrade script](miscellaneous/postgres-upgrade-job.yaml) for customers using the internal Postgres pod


### PR DESCRIPTION
Adds a `regexp_tree` dictionary that categorizes user-agent strings at ingest. This dictionary groups high-cardinality user-agent values into categories such as

- search engine crawlers
- AI crawlers
- desktop browsers
 
Includes a readme covering the schema and transform usage.

This will be used in the soon-to-be published [Regexp Tree Dictionaries](https://docs.hydrolix.io/docs/regexp-tree-dictionaries) documentation.