### PR TITLE
typographical correction for User-Agent header

### DIFF
--- a/dictionaries/user_agent_regex/readme.md
+++ b/dictionaries/user_agent_regex/readme.md
@@ -1,6 +1,6 @@
 # User-Agent Regexp Dictionary
 
-A [regexp tree dictionary](https://docs.hydrolix.io/docs/regexp-tree-dictionaries) that categorizes `User-~gent` strings during ingest. It groups high-cardinality user agent values into a small set of categories such as search engine crawlers, AI crawlers, and desktop browsers, so you can index, group by, and filter on the category instead of the raw string.
+A [regexp tree dictionary](https://docs.hydrolix.io/docs/regexp-tree-dictionaries) that categorizes `User-Agent` strings during ingest. It groups high-cardinality user agent values into a small set of categories such as search engine crawlers, AI crawlers, and desktop browsers, so you can index, group by, and filter on the category instead of the raw string.
 
 The dictionary file is [`user_agent_regex_dict.yaml`](user_agent_regex_dict.yaml).
 


### PR DESCRIPTION
## What changed?

This corrects a typographical error I introduced in #20.
